### PR TITLE
[Feature 002] T050 — Fix adversarial review findings (M1, M2, M3, L3)

### DIFF
--- a/platform/photo-agent/docs/facebook/01-create-app.md
+++ b/platform/photo-agent/docs/facebook/01-create-app.md
@@ -179,7 +179,7 @@ The account that runs the OAuth flow must be an admin of the target Page.
 
 ## Part F — Add credentials to `.env`
 
-Open `clients/_demo/src/photo-agent/.env` (copy from `.env.example` first if it doesn't exist):
+Open `clients/<client>/src/photo-agent/.env` (copy from `.env.example` first if it doesn't exist):
 
 ```bash
 FB_APP_ID=<App ID from Part C>
@@ -187,7 +187,7 @@ FB_APP_SECRET=<App Secret from Part C>
 ```
 
 ```bash
-chmod 600 clients/_demo/src/photo-agent/.env
+chmod 600 clients/<client>/src/photo-agent/.env
 ```
 
 Leave `FB_PAGE_ID` and `FB_PAGE_ACCESS_TOKEN` blank for now — doc 2 covers getting those.

--- a/platform/photo-agent/scripts/check_approval.py
+++ b/platform/photo-agent/scripts/check_approval.py
@@ -123,7 +123,8 @@ def _get_tmp_root() -> Path:
     if tmp_raw:
         p = Path(tmp_raw)
         return (p if p.is_absolute() else (_REPO_ROOT / p)).resolve()
-    return (_REPO_ROOT / "data" / "photo-agent" / "tmp").resolve()
+    # Default to client-specific data dir so clients never share a tmp directory.
+    return (Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent" / "tmp").resolve()
 
 
 def _delete_local_file(video_local_path: str, project_name: str) -> None:

--- a/platform/photo-agent/scripts/process_photos.py
+++ b/platform/photo-agent/scripts/process_photos.py
@@ -147,7 +147,8 @@ def main(argv=None) -> None:
         p = Path(tmp_base_raw)
         tmp_base = p if p.is_absolute() else (_REPO_ROOT / p).resolve()
     else:
-        tmp_base = _REPO_ROOT / "data" / "photo-agent" / "tmp"
+        # Default to the client-specific data dir so clients never share a tmp directory.
+        tmp_base = Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent" / "tmp"
 
     try:
         lock_f = _acquire_run_lock()

--- a/platform/photo-agent/scripts/upload_facebook.py
+++ b/platform/photo-agent/scripts/upload_facebook.py
@@ -52,7 +52,8 @@ def _get_tmp_root() -> Path:
     if tmp_raw:
         p = Path(tmp_raw)
         return (p if p.is_absolute() else (_REPO_ROOT / p)).resolve()
-    return (_REPO_ROOT / "data" / "photo-agent" / "tmp").resolve()
+    # Default to client-specific data dir so clients never share a tmp directory.
+    return (Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent" / "tmp").resolve()
 
 
 def _delete_local_file(video_local_path: str, project_name: str) -> None:

--- a/platform/photo-agent/tools/facebook_logger.py
+++ b/platform/photo-agent/tools/facebook_logger.py
@@ -1,7 +1,7 @@
 """
 Activity log writer for Facebook video upload events.
 
-Appends structured pipe-delimited lines to <repo-root>/logs/photo-agent.log
+Appends structured pipe-delimited lines to $FIELDKIT_LOG_DIR/photo-agent.log
 (the same file as logger.py). Each function corresponds to a distinct lifecycle
 event in the Facebook video upload pipeline.
 

--- a/platform/photo-agent/tools/facebook_state.py
+++ b/platform/photo-agent/tools/facebook_state.py
@@ -2,7 +2,7 @@
 State manager for the Facebook video upload pipeline.
 
 Manages:
-  <repo-root>/data/photo-agent/facebook_state.json
+  $FIELDKIT_DATA_DIR/photo-agent/facebook_state.json
     — pending VideoUploadJob record + published idempotency keys
 
 All read-modify-write operations acquire an exclusive file lock (fcntl.LOCK_EX)

--- a/platform/photo-agent/tools/logger.py
+++ b/platform/photo-agent/tools/logger.py
@@ -1,7 +1,7 @@
 """
 Activity log writer for the photo-video agent.
 
-Appends structured human-readable lines to <repo-root>/logs/photo-agent.log.
+Appends structured human-readable lines to $FIELDKIT_LOG_DIR/photo-agent.log.
 Each function corresponds to a distinct lifecycle event in the photo pipeline.
 The log directory is created on first write if it does not exist.
 

--- a/platform/photo-agent/tools/state.py
+++ b/platform/photo-agent/tools/state.py
@@ -2,7 +2,7 @@
 State manager for the photo-video agent.
 
 Manages:
-  <repo-root>/data/photo-agent/state.json  — pending approval record + Telegram update offset
+  $FIELDKIT_DATA_DIR/photo-agent/state.json  — pending approval record + Telegram update offset
 
 All read-modify-write operations acquire an exclusive file lock (fcntl.LOCK_EX) before
 reading and release it after writing. This prevents corruption when process_photos.py


### PR DESCRIPTION
## Summary

Follow-up to #3 — adversarial review findings that weren't included in the squash merge.

- **M1 (correctness)**: `VIDEO_TMP_DIR` default now resolves to `$FIELDKIT_DATA_DIR/photo-agent/tmp` instead of `_REPO_ROOT/data/photo-agent/tmp`. Prevents `_demo` and `_construction_co` from sharing the same tmp directory and colliding on same-named projects. Affects `process_photos.py`, `check_approval.py`, `upload_facebook.py`. Also removes the now-redundant explicit `VIDEO_TMP_DIR=data/photo-agent/tmp` from both client `.env` files.

- **M2 (docs)**: Docstrings in `state.py`, `logger.py`, `facebook_state.py`, `facebook_logger.py` updated from `<repo-root>/data/...` to `$FIELDKIT_DATA_DIR/...` and `$FIELDKIT_LOG_DIR/...`.

- **M3 (docs)**: `docs/facebook/01-create-app.md` Part F now says `clients/<client>/src/photo-agent/.env` instead of `clients/_demo/...`.

- **L3 (ops safety)**: Added `GOOGLE_USER_CREDENTIALS_FILE` reminder to `_construction_co/.env` so it's obvious that Drive auth needs a separate credentials file, not the `_demo` account's `~/.config/gws/user_credentials.json`.

## Test plan

- [ ] `cd platform/photo-agent && pytest tests/ -v` — 368 tests pass
- [ ] Confirm `_get_tmp_root()` in process_photos / check_approval / upload_facebook returns a client-specific path when `VIDEO_TMP_DIR` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)