### PR TITLE
Document cross-vendor review process for fieldkit PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ env/
 .env
 !.env.example
 
+# Omnigent per-session Codex home (auth.json copy, sqlite state) — created
+# by `omnigent run --harness codex` invocations in this directory
+.codex-tmp/
+
 
 # Editor
 .vscode/

--- a/platform/docs/cross-review.md
+++ b/platform/docs/cross-review.md
@@ -137,9 +137,13 @@ untrusted content through a file instead of a shell string, for that reason.
 
    # Everything that touches .codex-tmp/ is scoped to this subshell so
    # cleanup runs the moment `omnigent run` finishes, not whenever this
-   # terminal session eventually closes.
+   # terminal session eventually closes. `pipefail` matters here as much
+   # as `-e`: without it, a failed `omnigent run` piped through `tee`
+   # still exits 0 (tee's own exit status), so a real review failure
+   # would silently look like success -- verified live: `false | tee
+   # /dev/null` returns 0 under plain `set -e`, but 1 under `pipefail`.
    (
-     set -e
+     set -euo pipefail
      # Pre-create .codex-tmp restricted to this user BEFORE omnigent ever
      # touches it -- omnigent's own `mkdir(parents=True, exist_ok=True)`
      # call reuses an existing directory as-is without loosening its
@@ -152,21 +156,48 @@ untrusted content through a file instead of a shell string, for that reason.
      mkdir -p .codex-tmp
      chmod 700 .codex-tmp
 
-     # Cleanup must never blindly `rm -rf .codex-tmp` -- if that directory
-     # pre-existed for an unrelated reason, that would destroy it. Instead,
-     # mark "now" with a sentinel file, then on exit remove only the
-     # subdirectories Omnigent created *after* that point -- i.e. only
-     # this run's own session directory.
-     SENTINEL=$(mktemp)
-     trap 'find .codex-tmp -mindepth 1 -maxdepth 1 -type d -newer "$SENTINEL" -exec rm -rf {} +; rm -f "$SENTINEL"' EXIT
+     # Cleanup must identify the exact directory THIS run created, not
+     # "whatever looks new" -- a purely time-based guard (e.g. "delete
+     # anything newer than a sentinel") also deletes a sibling directory
+     # from a concurrent omnigent invocation that happens to start in the
+     # same window, since that's newer too. Snapshot .codex-tmp/'s entries
+     # before and after instead, and only auto-remove when the before/after
+     # diff is unambiguous (exactly one new entry). If it's not -- e.g. a
+     # concurrent session's directory really did appear alongside this
+     # run's -- leave everything for manual review rather than guessing;
+     # every entry is still 700-equivalent (Omnigent's own mkdtemp) either
+     # way, so leaving one behind isn't a credential-exposure regression.
+     BEFORE_LIST=$(mktemp)
+     ls -A .codex-tmp > "$BEFORE_LIST" 2>/dev/null || true
+
+     cleanup() {
+       local after new_entries new_count
+       after=$(mktemp)
+       ls -A .codex-tmp > "$after" 2>/dev/null || true
+       new_entries=$(comm -13 <(sort "$BEFORE_LIST") <(sort "$after"))
+       new_count=$(printf '%s\n' "$new_entries" | grep -c . || true)
+       if [ "$new_count" -eq 1 ]; then
+         rm -rf -- ".codex-tmp/$new_entries"
+       elif [ "$new_count" -gt 1 ]; then
+         echo "WARNING: $new_count new .codex-tmp/ entries appeared during" \
+              "this run (possible concurrent omnigent session) -- not" \
+              "auto-removing any of them, review manually:" >&2
+         printf '  %s\n' $new_entries >&2
+       fi
+       rm -f "$BEFORE_LIST" "$after"
+     }
+     trap cleanup EXIT
 
      omnigent run --harness codex --no-log -p "$(cat "$PROMPT_FILE")" \
        | tee "$REVIEW_FILE"
    )
-   # cleanup trap above already fired on subshell exit (success or
-   # failure). $PROMPT_FILE and $REVIEW_FILE are untouched by it and
-   # still valid here -- step 5 uses $REVIEW_FILE, then:
+   OMNIGENT_STATUS=$?
    rm -f "$PROMPT_FILE"
+   if [ "$OMNIGENT_STATUS" -ne 0 ]; then
+     echo "omnigent run failed (exit $OMNIGENT_STATUS) -- do NOT proceed to" \
+          "step 5 with a partial/empty review. Re-run step 3, or" \
+          "investigate the failure above first." >&2
+   fi
    ```
 
    `-p` passes the whole prompt file as one argv element, which is subject
@@ -175,10 +206,17 @@ untrusted content through a file instead of a shell string, for that reason.
    single-PR diff, but if a diff is unusually large and `omnigent run`
    fails with an argument-list-too-long-style error, there's no documented
    stdin-based alternative for the first message as of this writing — the
-   practical workaround is to scope the diff (review large/generated files
-   separately, or exclude vendored/lockfile-style hunks with
-   `gh pr diff ... -- . ':!path/to/lockfile'`) rather than pasting the
-   entire diff unfiltered.
+   practical workaround is to scope the diff down with `gh pr diff`'s own
+   repeatable `--exclude <glob>` flag (**not** a git pathspec — `gh pr diff`
+   takes only a single PR argument plus its own flags, so `-- path` / `:!path`
+   syntax is silently rejected):
+   ```bash
+   gh pr diff <pr-number> --repo sandeepkesarkar/fieldkit \
+     --exclude '*.lock' --exclude 'generated/*' >> "$PROMPT_FILE"
+   ```
+   verified against the installed `gh` (2.92.0): `--exclude` actually drops
+   the matching files' hunks from the diff output, unlike the pathspec
+   syntax this doc previously (incorrectly) suggested.
 
 4. Blocking findings → fix them, push the update, and re-run steps 1–3
    against the updated diff (mirrors Polly's own fix-loop in

--- a/platform/docs/cross-review.md
+++ b/platform/docs/cross-review.md
@@ -214,12 +214,20 @@ untrusted content through a file instead of a shell string, for that reason.
      # A plain pipeline statement here would trip `set -e` immediately on
      # failure, before $OMNIGENT_OK could ever be set to reflect that --
      # using it as an `if` condition is exempt from `set -e`'s early exit,
-     # so both branches always run to completion.
+     # so both branches always run to completion. Capture the failure via
+     # plain `$?`, not `${PIPESTATUS[0]}` / `$pipestatus[1]` -- those
+     # arrays are bash- and zsh-specific respectively (different name,
+     # different indexing), and under zsh with `set -u` referencing the
+     # bash-only `PIPESTATUS` aborts outright before this branch can even
+     # finish. `pipefail` (already set above) makes plain `$?` immediately
+     # after the pipeline equal to the *pipeline's* real exit status in
+     # both shells, with no array needed at all -- verified live in bash
+     # and zsh 5.9 (macOS default).
      if omnigent run --harness codex --no-log -p "$(cat "$PROMPT_FILE")" \
           | tee "$REVIEW_FILE"; then
        OMNIGENT_OK=1
      else
-       PIPE_STATUS=${PIPESTATUS[0]}
+       PIPE_STATUS=$?
      fi
      [ "$OMNIGENT_OK" -eq 1 ] || exit "$PIPE_STATUS"
    )

--- a/platform/docs/cross-review.md
+++ b/platform/docs/cross-review.md
@@ -1,17 +1,21 @@
 # Cross-Vendor Review for fieldkit PRs
 
 Implements `dev-infrastructure/specs/github-task-workflow.md` FR-011 / SC-006
-("Every code PR MUST carry a cross-vendor review... before being labeled
-`needs-approval`") for fieldkit specifically. fieldkit issues aren't worked
-through Polly/the poller (those are scoped to `dev-infrastructure` only, per
-the Rollout Phase decision in `dev-infrastructure/specs/omnigent-setup.md`) —
-so unlike `dev-infrastructure`, where Polly's `cross-review` skill dispatches
-this automatically, here it's a step the implementer (so far, always me) runs
-by hand before flipping a PR to `needs-approval`.
+for fieldkit specifically — that upstream spec's own wording is "Every code
+PR MUST carry a cross-vendor review... before being labeled `needs-approval`"
+(dev-infrastructure-wide phrasing; quoted here for traceability, not as
+fieldkit's scope statement — see **Scope** below for that). fieldkit issues
+aren't worked through Polly/the poller (those are scoped to
+`dev-infrastructure` only, per the Rollout Phase decision in
+`dev-infrastructure/specs/omnigent-setup.md`) — so unlike `dev-infrastructure`,
+where Polly's `cross-review` skill dispatches this automatically, here it's a
+step the implementer (so far, always me) runs by hand before flipping a PR to
+`needs-approval`.
 
-**Scope:** every fieldkit PR from issue #7 onward. (This doc's own PR, #17,
-and the two PRs before it, #15 and #16, predate or introduce the mechanism —
-see "Known gap" below for exactly what that means for each.)
+**Scope:** every fieldkit PR from issue #7 onward — the one authoritative
+statement of scope for this doc. (This doc's own PR, #17, and the two PRs
+before it, #15 and #16, predate or introduce the mechanism — see "Known gap"
+below for exactly what that means for each.)
 
 **No linked issue?** Not every PR maps to a GitHub issue (this doc's own PR
 is an example — process documentation, not part of an issue breakdown). When
@@ -62,11 +66,17 @@ the invoking shell would interpret those before Codex or `gh` ever see them
 (command injection in the documented procedure itself). Both steps route
 untrusted content through a file instead of a shell string, for that reason.
 
-1. Gather the diff and the issue's acceptance criteria (skip the `gh issue
-   view` call if there's no linked issue — see "No linked issue?" above):
+1. Gather the diff and the acceptance criteria. If the PR has a linked
+   issue, pull the criteria from there; otherwise use the PR description
+   itself (see "No linked issue?" above) — only one of the two `gh` calls
+   below is needed, not both:
    ```bash
    gh pr diff <pr-number> --repo sandeepkesarkar/fieldkit
-   gh issue view <issue-number> --repo sandeepkesarkar/fieldkit --json body
+
+   # has a linked issue:
+   gh issue view <issue-number> --repo sandeepkesarkar/fieldkit --json body -q .body
+   # no linked issue -- use the PR description instead:
+   gh pr view <pr-number> --repo sandeepkesarkar/fieldkit --json body -q .body
    ```
 
 2. Read the current Standing Review Dimensions. The range below is
@@ -82,23 +92,33 @@ untrusted content through a file instead of a shell string, for that reason.
    directly into a shell string), then pass it to `omnigent run` via command
    substitution on the *whole file* — bash does not re-expand the content of
    a `$(...)` substitution, so this is safe even though the file itself
-   contains untrusted text. A `trap` guarantees `.codex-tmp/` (Omnigent's
-   per-session Codex home, which includes an `auth.json` copy per the
-   `.gitignore` entry) is removed on both the success and failure path:
+   contains untrusted text.
+
+   `omnigent run --harness codex` creates `.codex-tmp/` itself, relative to
+   the cwd it's launched from — that path is hardcoded in Omnigent
+   (`codex_executor.py`, not configurable via `CODEX_HOME` or similar), and
+   it holds an `auth.json` copy for the life of the session. Build the
+   prompt file first in the current shell (its value needs to survive into
+   step 5), then run **only the `omnigent` invocation itself** inside a
+   subshell with its own `trap` — that scopes cleanup to fire the moment
+   that subshell exits (i.e. right after `omnigent run` completes), instead
+   of a shell-level `EXIT` trap, which would only fire when the *entire
+   pasted-into-terminal interactive shell* eventually closes, leaving
+   `.codex-tmp/` exposed for the rest of that terminal session:
 
    ```bash
    cd ~/src/fieldkit
-   trap 'rm -rf .codex-tmp' EXIT
-
    PROMPT_FILE=$(mktemp)
+   REVIEW_FILE=$(mktemp)
+
    cat > "$PROMPT_FILE" <<'PROMPT_EOF'
    Review this diff against the acceptance contract below. Do NOT edit any
    files -- report only.
 
    === ACCEPTANCE CONTRACT ===
    PROMPT_EOF
-   # Issue body if there is one (see "No linked issue?"), else paste the PR
-   # description instead -- either way, append via redirection, not `-p`:
+   # Issue body if there is one, else the PR description (see step 1 /
+   # "No linked issue?") -- either way, append via redirection, not `-p`:
    gh issue view <issue-number> --repo sandeepkesarkar/fieldkit --json body -q .body \
      >> "$PROMPT_FILE"
 
@@ -115,39 +135,63 @@ untrusted content through a file instead of a shell string, for that reason.
    separately, grouped by dimension, each with file:line evidence. If a
    dimension finds nothing, say so explicitly.\n' >> "$PROMPT_FILE"
 
-   omnigent run --harness codex --no-log -p "$(cat "$PROMPT_FILE")" \
-     | tee /tmp/cross-review-output.txt
+   # Everything that touches .codex-tmp/ is scoped to this subshell so
+   # cleanup runs the moment `omnigent run` finishes, not whenever this
+   # terminal session eventually closes.
+   (
+     set -e
+     # Pre-create .codex-tmp restricted to this user BEFORE omnigent ever
+     # touches it -- omnigent's own `mkdir(parents=True, exist_ok=True)`
+     # call reuses an existing directory as-is without loosening its
+     # permissions, so this closes the exposure window for the whole run
+     # rather than chmod-ing after the fact. (The per-session subdirectory
+     # Omnigent creates inside it via Python's `tempfile.mkdtemp` is
+     # already 0700 by default -- this step is only needed for the shared
+     # parent, which Omnigent creates with plain `mkdir` at default
+     # (umask-dependent) permissions.)
+     mkdir -p .codex-tmp
+     chmod 700 .codex-tmp
 
+     # Cleanup must never blindly `rm -rf .codex-tmp` -- if that directory
+     # pre-existed for an unrelated reason, that would destroy it. Instead,
+     # mark "now" with a sentinel file, then on exit remove only the
+     # subdirectories Omnigent created *after* that point -- i.e. only
+     # this run's own session directory.
+     SENTINEL=$(mktemp)
+     trap 'find .codex-tmp -mindepth 1 -maxdepth 1 -type d -newer "$SENTINEL" -exec rm -rf {} +; rm -f "$SENTINEL"' EXIT
+
+     omnigent run --harness codex --no-log -p "$(cat "$PROMPT_FILE")" \
+       | tee "$REVIEW_FILE"
+   )
+   # cleanup trap above already fired on subshell exit (success or
+   # failure). $PROMPT_FILE and $REVIEW_FILE are untouched by it and
+   # still valid here -- step 5 uses $REVIEW_FILE, then:
    rm -f "$PROMPT_FILE"
-   # trap fires here on exit (success or failure), removing .codex-tmp/
    ```
 
-   Immediately after `omnigent run --harness codex` creates `.codex-tmp/`
-   (and before the `trap` cleanup fires), it holds a copy of `auth.json`.
-   Restrict access for the life of that directory in case the trap doesn't
-   get a chance to run (e.g. a killed shell):
-   ```bash
-   chmod 700 .codex-tmp 2>/dev/null
-   chmod 600 .codex-tmp/auth.json 2>/dev/null
-   ```
-   Add this right after the `omnigent run` invocation starts producing
-   `.codex-tmp/`, or fold it into a wrapper script if this procedure gets
-   automated later.
+   `-p` passes the whole prompt file as one argv element, which is subject
+   to the OS's argv/environment size limit (`getconf ARG_MAX` — commonly
+   ~1MB on macOS, higher on Linux). This is normally not a problem for a
+   single-PR diff, but if a diff is unusually large and `omnigent run`
+   fails with an argument-list-too-long-style error, there's no documented
+   stdin-based alternative for the first message as of this writing — the
+   practical workaround is to scope the diff (review large/generated files
+   separately, or exclude vendored/lockfile-style hunks with
+   `gh pr diff ... -- . ':!path/to/lockfile'`) rather than pasting the
+   entire diff unfiltered.
 
 4. Blocking findings → fix them, push the update, and re-run steps 1–3
    against the updated diff (mirrors Polly's own fix-loop in
    `cross-review/SKILL.md` step 5). Clean → proceed.
 
-5. Post the review output as a PR comment straight from the file captured in
-   step 3 (`-F`/`--body-file` reads the file directly — no shell
-   interpolation of the untrusted review text at all), *then* post the
-   one-line issue summary and flip the label to `needs-approval` — the
-   review comment must already be on the PR before it reaches that state,
-   per SC-006:
+5. Post the review output as a PR comment straight from `$REVIEW_FILE`
+   (`-F`/`--body-file` reads the file directly — no shell interpolation of
+   the untrusted review text at all), *then* post the one-line issue
+   summary and flip the label to `needs-approval` — the review comment must
+   already be on the PR before it reaches that state, per SC-006:
    ```bash
-   gh pr comment <pr-number> --repo sandeepkesarkar/fieldkit \
-     -F /tmp/cross-review-output.txt
-   rm -f /tmp/cross-review-output.txt
+   gh pr comment <pr-number> --repo sandeepkesarkar/fieldkit -F "$REVIEW_FILE"
+   rm -f "$REVIEW_FILE"
    ```
 
 ## Known gap
@@ -174,4 +218,5 @@ merged PRs before this one differ:
   dedicated issue exists, treat #16's cross-review findings as open and
   unresolved — do not treat #16 as clean precedent.
 
-Every fieldkit PR from issue #7 onward goes through this procedure.
+See **Scope** at the top for which PRs this procedure applies to going
+forward.

--- a/platform/docs/cross-review.md
+++ b/platform/docs/cross-review.md
@@ -9,6 +9,16 @@ so unlike `dev-infrastructure`, where Polly's `cross-review` skill dispatches
 this automatically, here it's a step the implementer (so far, always me) runs
 by hand before flipping a PR to `needs-approval`.
 
+**Scope:** every fieldkit PR from issue #7 onward. (This doc's own PR, #17,
+and the two PRs before it, #15 and #16, predate or introduce the mechanism —
+see "Known gap" below for exactly what that means for each.)
+
+**No linked issue?** Not every PR maps to a GitHub issue (this doc's own PR
+is an example — process documentation, not part of an issue breakdown). When
+there's no issue to pull an acceptance contract from, use the PR description
+instead: its "Summary" and any explicitly stated goals stand in for the
+`ACCEPTANCE CONTRACT` section in step 3 below.
+
 ## Why this mechanism specifically
 
 - **Codex, not another vendor** — matches the pinned-reviewer decision made
@@ -19,9 +29,20 @@ by hand before flipping a PR to `needs-approval`.
   `~/.zshrc`) over the ChatGPT subscription login whenever both are present,
   billing pay-per-token instead (the exact bug fixed for `dev-infrastructure`
   in `omnigent-setup.md`, "`codex-native` still billed the API key anyway").
-  Omnigent's non-native `codex` harness strips that env var before launch —
-  confirmed working from this directory: `total_cost_usd: None` on the
-  session record (no token-priced billing recorded) after a live test call.
+  This isn't inferred from a billing record after the fact — it's how the
+  harness is built: Omnigent's installed `codex` (non-native) harness
+  excludes `OPENAI_API_KEY` from the subprocess environment by construction.
+  In the installed package (`omnigent/inner/codex_executor.py`,
+  `_CODEX_ENV_DENY_EXACT = frozenset({"OPENAI_API_KEY"})`, with the env
+  filter applied in `_build_codex_env`), the source comment states the
+  reason directly: *"`OPENAI_API_KEY` is stripped so the codex CLI falls
+  back to subscription auth (`auth.json`) rather than a developer API key
+  that would charge separately."* This matches `dev-infrastructure`'s own
+  root-cause writeup for the same fix. A live test call from this directory
+  (`omnigent run --harness codex --no-log -p "..."`) returned
+  `total_cost_usd: None` on the session record, which is consistent with
+  subscription billing — corroborating, not proving, the point on its own;
+  the env-stripping behavior in the harness source is the actual guarantee.
 - **Same review contract, not a duplicate one** — the actual checklist
   (Engineering + Security dimensions) lives in exactly one place,
   `dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md`'s
@@ -34,53 +55,123 @@ by hand before flipping a PR to `needs-approval`.
 Run after a PR is open and its own tests/verification pass, before posting
 the summary comment on the issue and flipping its label to `needs-approval`.
 
-1. Gather the diff and the issue's acceptance criteria:
+Steps 3 and 5 below pass untrusted content (a PR diff, an issue body, review
+output) to shell commands. That content can contain backticks, `$(...)`,
+`$VAR`, or quotes — if pasted directly into a double-quoted shell argument,
+the invoking shell would interpret those before Codex or `gh` ever see them
+(command injection in the documented procedure itself). Both steps route
+untrusted content through a file instead of a shell string, for that reason.
+
+1. Gather the diff and the issue's acceptance criteria (skip the `gh issue
+   view` call if there's no linked issue — see "No linked issue?" above):
    ```bash
    gh pr diff <pr-number> --repo sandeepkesarkar/fieldkit
    gh issue view <issue-number> --repo sandeepkesarkar/fieldkit --json body
    ```
 
-2. Read the current Standing Review Dimensions:
+2. Read the current Standing Review Dimensions. The range below is
+   deliberately trimmed with a second pass so the output doesn't include the
+   trailing `## Notes` heading itself:
    ```bash
    sed -n '/## Standing review dimensions/,/^## Notes/p' \
-     ~/src/dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md
+     ~/src/dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md \
+     | sed '$d'
    ```
 
-3. Dispatch Codex, headless, from the fieldkit repo root (so its shell tool
-   calls land in the right working directory if it wants to inspect files
-   beyond the diff):
+3. Build the prompt in a temp file (never interpolate the diff/issue body
+   directly into a shell string), then pass it to `omnigent run` via command
+   substitution on the *whole file* — bash does not re-expand the content of
+   a `$(...)` substitution, so this is safe even though the file itself
+   contains untrusted text. A `trap` guarantees `.codex-tmp/` (Omnigent's
+   per-session Codex home, which includes an `auth.json` copy per the
+   `.gitignore` entry) is removed on both the success and failure path:
+
    ```bash
    cd ~/src/fieldkit
-   omnigent run --harness codex --no-log -p "Review this diff against the acceptance
-   contract below. Do NOT edit any files -- report only.
+   trap 'rm -rf .codex-tmp' EXIT
 
-   === ACCEPTANCE CONTRACT (issue #<n>) ===
-   <issue body>
+   PROMPT_FILE=$(mktemp)
+   cat > "$PROMPT_FILE" <<'PROMPT_EOF'
+   Review this diff against the acceptance contract below. Do NOT edit any
+   files -- report only.
 
-   === STANDING REVIEW DIMENSIONS (apply in addition to the contract above) ===
-   <pasted section from step 2>
+   === ACCEPTANCE CONTRACT ===
+   PROMPT_EOF
+   # Issue body if there is one (see "No linked issue?"), else paste the PR
+   # description instead -- either way, append via redirection, not `-p`:
+   gh issue view <issue-number> --repo sandeepkesarkar/fieldkit --json body -q .body \
+     >> "$PROMPT_FILE"
 
-   === DIFF ===
-   <pasted diff from step 1>
+   printf '\n=== STANDING REVIEW DIMENSIONS (apply in addition to the contract above) ===\n' \
+     >> "$PROMPT_FILE"
+   sed -n '/## Standing review dimensions/,/^## Notes/p' \
+     ~/src/dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md \
+     | sed '$d' >> "$PROMPT_FILE"
 
-   Report blocking issues, non-blocking issues, and suggestions separately,
-   grouped by dimension, each with file:line evidence. If a dimension finds
-   nothing, say so explicitly."
+   printf '\n=== DIFF ===\n' >> "$PROMPT_FILE"
+   gh pr diff <pr-number> --repo sandeepkesarkar/fieldkit >> "$PROMPT_FILE"
+
+   printf '\nReport blocking issues, non-blocking issues, and suggestions
+   separately, grouped by dimension, each with file:line evidence. If a
+   dimension finds nothing, say so explicitly.\n' >> "$PROMPT_FILE"
+
+   omnigent run --harness codex --no-log -p "$(cat "$PROMPT_FILE")" \
+     | tee /tmp/cross-review-output.txt
+
+   rm -f "$PROMPT_FILE"
+   # trap fires here on exit (success or failure), removing .codex-tmp/
    ```
 
-4. Blocking findings → fix them, push the update, and re-run step 3 against
-   the updated diff (mirrors Polly's own fix-loop in `cross-review/SKILL.md`
-   step 5). Clean → proceed.
+   Immediately after `omnigent run --harness codex` creates `.codex-tmp/`
+   (and before the `trap` cleanup fires), it holds a copy of `auth.json`.
+   Restrict access for the life of that directory in case the trap doesn't
+   get a chance to run (e.g. a killed shell):
+   ```bash
+   chmod 700 .codex-tmp 2>/dev/null
+   chmod 600 .codex-tmp/auth.json 2>/dev/null
+   ```
+   Add this right after the `omnigent run` invocation starts producing
+   `.codex-tmp/`, or fold it into a wrapper script if this procedure gets
+   automated later.
 
-5. Post the review output as a PR comment (`gh pr comment <pr-number> --body
-   "..."`), *then* post the one-line issue summary and flip the label to
-   `needs-approval` — the review comment must already be on the PR before it
-   reaches that state, per SC-006.
+4. Blocking findings → fix them, push the update, and re-run steps 1–3
+   against the updated diff (mirrors Polly's own fix-loop in
+   `cross-review/SKILL.md` step 5). Clean → proceed.
+
+5. Post the review output as a PR comment straight from the file captured in
+   step 3 (`-F`/`--body-file` reads the file directly — no shell
+   interpolation of the untrusted review text at all), *then* post the
+   one-line issue summary and flip the label to `needs-approval` — the
+   review comment must already be on the PR before it reaches that state,
+   per SC-006:
+   ```bash
+   gh pr comment <pr-number> --repo sandeepkesarkar/fieldkit \
+     -F /tmp/cross-review-output.txt
+   rm -f /tmp/cross-review-output.txt
+   ```
 
 ## Known gap
 
-fieldkit PRs merged before this doc existed (#15 / issue #5, #16 / issue #6)
-went out without this step — done directly, before the mechanism existed.
-Not retroactively reviewed; not worth re-opening merged, working PRs to
-backfill a comment with no decision left to inform. Every fieldkit PR from
-issue #7 onward goes through this procedure.
+Not every fieldkit PR before this doc went through this procedure, and
+"predates the doc" doesn't uniformly mean "nothing outstanding" — the two
+merged PRs before this one differ:
+
+- **#15 / issue #5 (Install Hermes)** — merged before this mechanism
+  existed. No known open findings against it; not worth re-opening to
+  backfill a review comment with no decision left to inform.
+- **#16 / issue #6 (Configure Hermes Telegram gateway)** — also merged
+  before this mechanism existed, but an independent cross-vendor review run
+  against it afterward surfaced four blocking findings that are **still
+  unresolved**: OpenClaw's launchd gateway not durably disabled across
+  reboot, broken/incomplete OpenAI switch-over instructions, a false claim
+  about `OPENAI_API_KEY` being available, and unverified "Anthropic is
+  default provider" evidence. These are not fixed, and merging #16 didn't
+  resolve them. There is no single dedicated tracking issue for this
+  finding set as of this writing — the closest related open issues are #14
+  (OpenClaw uninstall, overlaps with the launchd-disable finding) and #12
+  (OpenAI-backed demo customer, overlaps with the switch-over-instructions
+  finding), but neither one names all four findings explicitly. Until a
+  dedicated issue exists, treat #16's cross-review findings as open and
+  unresolved — do not treat #16 as clean precedent.
+
+Every fieldkit PR from issue #7 onward goes through this procedure.

--- a/platform/docs/cross-review.md
+++ b/platform/docs/cross-review.md
@@ -1,0 +1,86 @@
+# Cross-Vendor Review for fieldkit PRs
+
+Implements `dev-infrastructure/specs/github-task-workflow.md` FR-011 / SC-006
+("Every code PR MUST carry a cross-vendor review... before being labeled
+`needs-approval`") for fieldkit specifically. fieldkit issues aren't worked
+through Polly/the poller (those are scoped to `dev-infrastructure` only, per
+the Rollout Phase decision in `dev-infrastructure/specs/omnigent-setup.md`) —
+so unlike `dev-infrastructure`, where Polly's `cross-review` skill dispatches
+this automatically, here it's a step the implementer (so far, always me) runs
+by hand before flipping a PR to `needs-approval`.
+
+## Why this mechanism specifically
+
+- **Codex, not another vendor** — matches the pinned-reviewer decision made
+  for `dev-infrastructure` (`omnigent/polly/skills/cross-review/SKILL.md`):
+  Claude implements, a different vendor reviews.
+- **`omnigent run --harness codex`, not the raw `codex` CLI directly** —
+  Codex CLI silently prefers `OPENAI_API_KEY` (globally exported in
+  `~/.zshrc`) over the ChatGPT subscription login whenever both are present,
+  billing pay-per-token instead (the exact bug fixed for `dev-infrastructure`
+  in `omnigent-setup.md`, "`codex-native` still billed the API key anyway").
+  Omnigent's non-native `codex` harness strips that env var before launch —
+  confirmed working from this directory: `total_cost_usd: None` on the
+  session record (no token-priced billing recorded) after a live test call.
+- **Same review contract, not a duplicate one** — the actual checklist
+  (Engineering + Security dimensions) lives in exactly one place,
+  `dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md`'s
+  "Standing review dimensions" section. Read it fresh at review time rather
+  than copy-pasting it here, so fieldkit never reviews against a stale copy
+  when that file gets extended with new dimensions later.
+
+## Procedure
+
+Run after a PR is open and its own tests/verification pass, before posting
+the summary comment on the issue and flipping its label to `needs-approval`.
+
+1. Gather the diff and the issue's acceptance criteria:
+   ```bash
+   gh pr diff <pr-number> --repo sandeepkesarkar/fieldkit
+   gh issue view <issue-number> --repo sandeepkesarkar/fieldkit --json body
+   ```
+
+2. Read the current Standing Review Dimensions:
+   ```bash
+   sed -n '/## Standing review dimensions/,/^## Notes/p' \
+     ~/src/dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md
+   ```
+
+3. Dispatch Codex, headless, from the fieldkit repo root (so its shell tool
+   calls land in the right working directory if it wants to inspect files
+   beyond the diff):
+   ```bash
+   cd ~/src/fieldkit
+   omnigent run --harness codex --no-log -p "Review this diff against the acceptance
+   contract below. Do NOT edit any files -- report only.
+
+   === ACCEPTANCE CONTRACT (issue #<n>) ===
+   <issue body>
+
+   === STANDING REVIEW DIMENSIONS (apply in addition to the contract above) ===
+   <pasted section from step 2>
+
+   === DIFF ===
+   <pasted diff from step 1>
+
+   Report blocking issues, non-blocking issues, and suggestions separately,
+   grouped by dimension, each with file:line evidence. If a dimension finds
+   nothing, say so explicitly."
+   ```
+
+4. Blocking findings → fix them, push the update, and re-run step 3 against
+   the updated diff (mirrors Polly's own fix-loop in `cross-review/SKILL.md`
+   step 5). Clean → proceed.
+
+5. Post the review output as a PR comment (`gh pr comment <pr-number> --body
+   "..."`), *then* post the one-line issue summary and flip the label to
+   `needs-approval` — the review comment must already be on the PR before it
+   reaches that state, per SC-006.
+
+## Known gap
+
+fieldkit PRs merged before this doc existed (#15 / issue #5, #16 / issue #6)
+went out without this step — done directly, before the mechanism existed.
+Not retroactively reviewed; not worth re-opening merged, working PRs to
+backfill a comment with no decision left to inform. Every fieldkit PR from
+issue #7 onward goes through this procedure.

--- a/platform/docs/cross-review.md
+++ b/platform/docs/cross-review.md
@@ -167,11 +167,34 @@ untrusted content through a file instead of a shell string, for that reason.
      # run's -- leave everything for manual review rather than guessing;
      # every entry is still 700-equivalent (Omnigent's own mkdtemp) either
      # way, so leaving one behind isn't a credential-exposure regression.
+     #
+     # That "exactly one new entry = ours" rule only holds when THIS run's
+     # own omnigent invocation actually succeeded. If it fails *before*
+     # creating its own session directory, while a genuinely concurrent,
+     # unrelated omnigent invocation creates its own directory in that same
+     # window, the before/after snapshot still shows exactly one new entry
+     # -- but it's the OTHER session's, not ours (proven live). Auto-
+     # removing on that basis would delete a live concurrent session's
+     # auth.json/state. So: automatic removal only ever runs on the
+     # success path, gated on $OMNIGENT_OK below. On any failure, leave
+     # .codex-tmp/ completely untouched -- whatever is or isn't in there --
+     # and let the operator inspect/clean it up by hand, since ownership
+     # can't be reliably established once this run itself didn't complete.
      BEFORE_LIST=$(mktemp)
      ls -A .codex-tmp > "$BEFORE_LIST" 2>/dev/null || true
+     OMNIGENT_OK=0
+     PIPE_STATUS=0
 
      cleanup() {
        local after new_entries new_count
+       if [ "$OMNIGENT_OK" -ne 1 ]; then
+         echo "omnigent run did not complete successfully -- leaving" \
+              ".codex-tmp/ untouched (ownership of any new entry can't be" \
+              "reliably established after a failure -- see comment above)." \
+              "Inspect it manually if cleanup is needed." >&2
+         rm -f "$BEFORE_LIST"
+         return
+       fi
        after=$(mktemp)
        ls -A .codex-tmp > "$after" 2>/dev/null || true
        new_entries=$(comm -13 <(sort "$BEFORE_LIST") <(sort "$after"))
@@ -188,8 +211,17 @@ untrusted content through a file instead of a shell string, for that reason.
      }
      trap cleanup EXIT
 
-     omnigent run --harness codex --no-log -p "$(cat "$PROMPT_FILE")" \
-       | tee "$REVIEW_FILE"
+     # A plain pipeline statement here would trip `set -e` immediately on
+     # failure, before $OMNIGENT_OK could ever be set to reflect that --
+     # using it as an `if` condition is exempt from `set -e`'s early exit,
+     # so both branches always run to completion.
+     if omnigent run --harness codex --no-log -p "$(cat "$PROMPT_FILE")" \
+          | tee "$REVIEW_FILE"; then
+       OMNIGENT_OK=1
+     else
+       PIPE_STATUS=${PIPESTATUS[0]}
+     fi
+     [ "$OMNIGENT_OK" -eq 1 ] || exit "$PIPE_STATUS"
    )
    OMNIGENT_STATUS=$?
    rm -f "$PROMPT_FILE"


### PR DESCRIPTION
## Summary

- Adds `platform/docs/cross-review.md` — documents how to run a Codex cross-vendor review (Engineering + Security) on fieldkit PRs before flipping them to `needs-approval`, implementing `dev-infrastructure`'s `github-task-workflow.md` FR-011/SC-006 for fieldkit.
- Since fieldkit issues aren't worked through Polly/the poller (dev-infrastructure-only per the Rollout Phase decision), this is a manual-but-documented step the implementer runs — `omnigent run --harness codex`, not the raw `codex` CLI (which would hit the `OPENAI_API_KEY`-over-subscription billing bug already fixed for dev-infrastructure).
- The review checklist itself isn't duplicated here — the doc reads it fresh from `dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md`'s "Standing review dimensions" section each time, so fieldkit never reviews against a stale copy.
- Gitignores `.codex-tmp/` (Omnigent's per-session Codex home, includes an `auth.json` copy) — created wherever `omnigent run --harness codex` is invoked.

Not tied to a GitHub issue (process documentation, not part of the original Platform 003 issue breakdown).

## Update — fixes from an independent cross-vendor review of this PR (round 1)

Rebased onto current `main` (now includes #16). Four blocking findings and three non-blocking findings from an independent review, all addressed with concrete doc changes:

**Blocking**

1. **"Known gap" section misrepresented #16 as a clean merge.** It previously lumped #15 and #16 together as "merged, working PRs" not worth backfilling review on. That's wrong for #16: an independent cross-vendor review run against it afterward found four still-unresolved blocking findings (OpenClaw's launchd gateway not durably disabled across reboot, broken/incomplete OpenAI switch-over instructions, a false claim about `OPENAI_API_KEY` availability, unverified "Anthropic is default provider" evidence). Rewrote the section to treat #15 and #16 separately: #15 has no known open findings; #16's findings are named explicitly and marked unresolved, with a pointer to the two related-but-not-exact-match open issues (#12, #14) and an explicit statement that no single issue tracks the full finding set yet.
2. **Billing-avoidance claim rested only on `total_cost_usd: None`,** which doesn't prove which auth path ran. Replaced/strengthened with the actual mechanism: Omnigent's installed `codex` (non-native) harness excludes `OPENAI_API_KEY` from the subprocess environment by construction — cited directly from the installed package (`omnigent/inner/codex_executor.py`, `_CODEX_ENV_DENY_EXACT = frozenset({"OPENAI_API_KEY"})`), whose own source comment states the reason. The `total_cost_usd: None` observation is kept only as corroborating evidence, explicitly labeled as such rather than as the proof.
3. **Command-injection risk in the documented procedure itself** — steps 3 and 5 pasted a raw PR diff / issue body / review output directly into double-quoted shell arguments (`omnigent run ... -p "..."`, `gh pr comment ... --body "..."`), so backticks/`$()`/`$VAR`/quotes in that untrusted content would be interpreted by the invoking shell. Rewrote both: step 3 now builds the prompt in a temp file via redirection and passes it with `-p "$(cat "$PROMPT_FILE")"` (command-substitution output is not re-expanded by bash, verified live before writing it into the doc); step 5 now uses `gh pr comment -F <file>`, which reads the body straight from disk with no shell interpolation at all.
4. **`.codex-tmp/` (holds an `auth.json` copy) was only `.gitignore`d,** which stops accidental commits but not local read access or credential lifecycle. Added `chmod 700 .codex-tmp` / `chmod 600 .codex-tmp/auth.json` right after it's created, plus an `EXIT` trap (`trap 'rm -rf .codex-tmp' EXIT`) around the `omnigent run` step so it's removed on both the success and failure path, not just left for `.gitignore` to hide.

**Non-blocking**

5. Added a "No linked issue?" note: when a PR has no linked GitHub issue (like this one), the PR description's Summary/stated goals stand in for the `ACCEPTANCE CONTRACT` section.
6. Reconciled the inconsistent scope language ("every code PR" near the top vs. "every fieldkit PR from issue #7 onward" at the bottom) into one statement, up top, that also explains where #15/#16/#17 itself fall relative to that boundary.
7. Tightened the Standing Review Dimensions `sed` range so it no longer prints the trailing `## Notes` heading (`sed -n '/.../,/^## Notes/p' | sed '$d'`), verified against the live `SKILL.md`.

## Update — round 2 fixes from a second independent cross-vendor review

A second independent review ran against the round-1 diff (commit `1381ac3`) and found the round-1 mitigations for finding 4 (`.codex-tmp` hardening) didn't actually close the gap they were meant to close. Two new blocking findings, four non-blocking, all addressed:

**Blocking**

1. **Cleanup timing was wrong for a pasted-into-terminal procedure.** The round-1 `trap ... EXIT` only fires when the *entire invoking shell* exits — for a script pasted into an interactive terminal, that's whenever the operator eventually closes that terminal session, not when `omnigent run` itself finishes. `.codex-tmp/` (with its `auth.json` copy) sat exposed for the rest of that session, not just for the command's own runtime. Fixed by scoping only the `omnigent run` invocation into its own subshell with its own `EXIT` trap, so cleanup fires the instant that subshell exits. `$PROMPT_FILE` / `$REVIEW_FILE` are built in the outer shell first (so `$REVIEW_FILE` still exists for step 5 after the subshell exits) — only the `.codex-tmp`-touching logic is inside the subshell.
2. **`chmod` was applied too late.** The round-1 doc only restricted permissions *after* the synchronous `omnigent run` pipeline completed, so the credential file sat at default (umask-dependent) permissions for the entire run. Fixed by pre-creating `.codex-tmp` via `mkdir -p` + `chmod 700` *before* invoking omnigent — Omnigent's own `mkdir(exist_ok=True)` call reuses an existing directory as-is without loosening its permissions, so this closes the window for the whole run rather than tightening it afterward. (Traced Omnigent's actual source, `codex_executor.py`: the per-session subdirectory it creates via Python's `tempfile.mkdtemp` is already `0700` by default — the real exposure was only in the shared parent directory, which Omnigent creates with a plain `mkdir` at default permissions.) Related sub-issue also raised: the round-1 doc's unconditional `rm -rf .codex-tmp` could have destroyed a pre-existing, unrelated directory at that path. Replaced with a sentinel-file + `find -newer` guard that removes only the session subdirectory *this run* created, never touching anything that existed beforehand.

**Non-blocking**

3. Added a `gh pr view --json body -q .body` fallback command alongside `gh issue view` in step 1, for PRs with no linked issue (this PR is itself an example).
4. Documented the `-p` flag's exposure to the OS argv/environment size limit (`getconf ARG_MAX`) for unusually large diffs, with a practical workaround (scope the diff / exclude vendored or lockfile-style hunks) rather than asserting an unverified stdin-based alternative.
5. Reconciled the remaining scope-language inconsistency: the upstream FR-011 quote ("every code PR...") is now explicitly labeled as dev-infrastructure-wide upstream phrasing, and the doc's own **Scope** line is now the single authoritative statement — the previously duplicated footer sentence was replaced with a pointer back to it.
6. Replaced the predictable, collision-prone `/tmp/cross-review-output.txt` with `REVIEW_FILE=$(mktemp)` throughout steps 3 and 5.

## Update — round 4 fixes from a fourth independent cross-vendor review

This review actually *executed* the documented procedure (not just read it) against the round-2 diff (commit `8cef0d7`) and found three real operational bugs that only surface by running the script:

**Blocking**

1. **A failed Codex review could be silently masked.** `set -e` alone doesn't catch a failure inside a pipe: `omnigent run ... | tee "$REVIEW_FILE"` exits with `tee`'s status (0), not omnigent's, if omnigent fails — verified live with `false | tee /dev/null` returning 0 under plain `set -e`. An operator could have proceeded to post/approve an empty or partial review without any error surfacing. Fixed: switched to `set -euo pipefail` inside the subshell (`false | tee /dev/null` now correctly returns 1), and since the omnigent call is itself inside a subshell, added an explicit `OMNIGENT_STATUS=$?` check right after it with a "do NOT proceed to step 5" warning printed if non-zero.
2. **The documented oversized-diff workaround didn't actually work.** The round-2 doc suggested `gh pr diff ... -- . ':!path/to/lockfile'` (git pathspec syntax), but the installed `gh pr diff` (2.92.0) only accepts a single PR argument plus its own flags — pathspecs are silently rejected. Verified live against PR #17's real diff that `gh pr diff`'s actual, repeatable `--exclude <glob>` flag does the job (confirmed the excluded file's `diff --git` header disappears from the output while the rest of the diff is untouched). Doc now documents and uses `--exclude`.
3. **The sentinel-based cleanup (round 2/3) was time-based, not ownership-based.** `find -newer $SENTINEL` deletes *anything* created after the sentinel timestamp — proven live to also delete a sibling directory belonging to a genuinely concurrent, unrelated omnigent invocation, not just this run's own session directory. That's a real risk of destroying another active session's working state. Replaced with a before/after snapshot of `.codex-tmp/`'s entries: if exactly one new entry appears (the normal case), remove it; if more than one appears (a real concurrent session), leave all of them untouched and print a manual-review warning instead of guessing which one is "ours" — every entry Omnigent creates is already `0700` regardless, so leaving one behind isn't a credential-exposure regression, just a slightly less tidy `.codex-tmp/`.

I verified all three fixes by extracting the *literal script text from the committed doc* (not a hand-written reconstruction) and running it against real `gh` output with a mocked `omnigent`, across three scenarios: normal success (only the run's own session dir removed, `.codex-tmp` left at `0700`), omnigent failing mid-pipe (`OMNIGENT_STATUS` correctly surfaces non-zero and the warning prints), and a genuinely concurrent second session directory appearing alongside this run's own (both correctly left untouched with a warning, neither deleted).

## Update — round 6 fix, one narrow edge case in the round-4 cleanup logic

A sixth independent review found and empirically reproduced one edge case the round-4 "exactly one new entry = ours" rule didn't cover:

**Blocking**

1. **The round-4 rule assumed any single new `.codex-tmp/` entry belongs to this run — but that's only true if this run actually succeeded in creating one.** If THIS invocation fails *before* it creates its own session directory, while a genuinely concurrent, unrelated omnigent invocation creates *its* directory in that same window, the before/after snapshot still shows exactly one new entry — the OTHER session's, not this run's. Reproduced live (`case=failed_before_own new_count=1 entries=concurrent-session`, `would_remove=.codex-tmp/concurrent-session`): the round-4 logic would have auto-deleted a live concurrent session's `auth.json`/state. Fixed by extending the existing `OMNIGENT_STATUS` gate (round 4) down into the `cleanup()` trap itself via a new `$OMNIGENT_OK` flag: automatic before/after-diff removal now only ever runs on the success path. On any failure, `.codex-tmp/` is left completely untouched — whatever is or isn't in there — and the operator is told to inspect it manually, since ownership can't be reliably established once this run itself didn't complete. (Setting `$OMNIGENT_OK` needed the omnigent pipeline to run as an `if` condition rather than a bare statement, since a bare pipeline would trip `set -e`'s immediate abort before the flag could ever be recorded — one of the standard `set -e` exemptions. The subshell still propagates the real failure code outward afterward via an explicit `exit`, so the outer round-4 "do NOT proceed to step 5" warning is unaffected.)

Verified by extracting the literal script from the committed doc and running it (real `gh`, mocked `omnigent`) through four scenarios: normal success (regression check — single new entry still auto-removed); ambiguous multiple new entries on the success path (regression check — both left with a warning, matching round 4); plain failure with no new entries (nothing touched); and Codex's exact reproduction (this run failing before creating its own directory while a concurrent session's directory appears in the same window) — that directory now correctly survives, instead of being deleted.

## Update — round 7 fix, shell-portable failure-status capture

Codex confirmed the round-6 cleanup-safety fix itself is genuinely resolved, but found one portability bug in how it captures the failure status:

**Blocking**

1. **The round-6 failure branch used `${PIPESTATUS[0]}` to recover the real omnigent exit code, but that array is bash-specific (zero-indexed).** zsh — the default shell on macOS, which this doc's audience is likely running — provides a differently-named, one-indexed `pipestatus` array instead. Reproduced live: under zsh with `set -u`, referencing the bash-only `PIPESTATUS` aborts with "parameter not set" before the branch can finish — it still lands in the safe don't-touch-`.codex-tmp` path by accident (so round 6's actual safety property held), but the real Omnigent exit status is lost and replaced with a generic `1`, which would mislead the operator about what actually failed. Fixed by capturing plain `$?` instead of either shell's array: with `pipefail` already enabled (round 4's `set -euo pipefail`, which zsh 5.9 also accepts natively — verified), `$?` immediately after a failed pipeline already equals the pipeline's own real exit status in both shells, so no shell-specific array is needed at all.

Verified by extracting the literal script from the committed doc and running the full regression suite under both `bash -c` and `zsh -c`: normal success, success with ambiguous multiple new entries, plain failure with a distinctive exit code (37) and no concurrent activity, and Codex's round-6 reproduction with a distinctive exit code (53) — failure before this run creates its own directory while a concurrent session's directory appears. All four scenarios behaved identically and correctly in both shells, and critically the real distinctive exit codes (37, 53) were faithfully surfaced rather than replaced by a generic `1` — confirming the actual reported bug is fixed, not just coincidentally still safe.

## Test plan

- [x] Verified the invocation path live: `omnigent run --harness codex --no-log -p "..."` from `~/src/fieldkit` responded correctly; the doc no longer treats `total_cost_usd: None` alone as proof of billing behavior (round 1, finding 2).
- [x] Dry-ran the round-1 prompt-file construction against real `gh pr diff` / `gh issue view` / `sed` output — confirmed backticks, `$()`, `$VAR`, and quotes in file content are not re-expanded when passed via `"$(cat "$PROMPT_FILE")"`.
- [x] Dry-ran the round-2 rewritten script end-to-end against a mock `omnigent` binary, seeding `.codex-tmp/` with a pre-existing unrelated file and injection-payload content (backticks, `$()`, `$HOME`, quotes) in the prompt. Confirmed: the injection payloads stayed inert (passed through literally, never executed), `.codex-tmp` ended at `drwx------` (700), the pre-existing unrelated file survived cleanup, only the run's own newly-created session subdirectory was removed, `$PROMPT_FILE` was removed, and `$REVIEW_FILE` correctly persisted past the subshell for step 5 to use.
- [x] Verified the tightened `sed` range against the live `dev-infrastructure/omnigent/polly/skills/cross-review/SKILL.md` — output no longer includes the `## Notes` heading.
- [x] Verified `--exclude` against the real installed `gh` CLI (2.92.0) and PR #17's actual diff — the excluded file's hunk is genuinely absent from the output, other files are untouched.
- [x] Extracted the literal round-4 script from the committed doc and ran it (real `gh`, mocked `omnigent`) through success, failure, and genuine-concurrency scenarios — all three behaved correctly (see round 4 update above for details).
- [x] Extracted the literal round-6 script from the committed doc and ran it through four scenarios, including Codex's exact reproduction (this run failing before creating its own session dir while a concurrent dir appears) — see round 6 update above for details.
- [x] Extracted the literal round-7 script from the committed doc and ran the full four-scenario regression suite under both `bash -c` and `zsh -c`, using distinctive non-1 exit codes (37, 53) to confirm the real failure status survives in both shells rather than being replaced by a generic `1` — see round 7 update above for details.
- No code change — docs + `.gitignore` only, so no test suite applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



