### PR TITLE
Point fieldkit's Omnigent config at dev-infrastructure's Polly

### DIFF
--- a/.omnigent/config.yaml
+++ b/.omnigent/config.yaml
@@ -1,0 +1,9 @@
+# Points at dev-infrastructure's committed Polly config (single source of
+# truth for cross-vendor review pinning, cost cap, and skills) rather than
+# vendoring a copy here. Assumes fieldkit and dev-infrastructure are checked
+# out as sibling directories (true on servicehub-dev, the only machine this
+# runs on). `omnigent run` (no args) from this repo now launches Polly
+# scoped to this workspace -- matching dev-infrastructure's own setup, so
+# fieldkit work gets the same automatic Codex cross-review when routed
+# through Polly instead of run directly.
+default_agent: ../dev-infrastructure/omnigent/polly/config.yaml


### PR DESCRIPTION
## Summary

- Adds `.omnigent/config.yaml` pointing `default_agent` at `../dev-infrastructure/omnigent/polly/config.yaml`.
- \`omnigent run\` (no args) from this repo now launches Polly scoped to the fieldkit workspace — verified live (\`Claude → Subscription\`, \`Codex → Subscription\`, workspace \`~/src/fieldkit\`).
- Means fieldkit work can now be routed through Polly (instead of a direct Claude Code session) to get automatic Codex cross-review, matching how dev-infrastructure already works — closes the gap where cross-review was a manual step I had to remember to bolt on (see \`platform/docs/cross-review.md\`).
- Points at dev-infrastructure's config rather than vendoring a copy — single source of truth, same pattern already used for the labels glossary.

Not tied to a GitHub issue (tooling/process config, not part of the Platform 003 issue breakdown). No cross-review needed (pure config, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)