### PR TITLE
Wire fieldkit to consume public agent-dev-kit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".agents/agent-dev-kit"]
+	path = .agents/agent-dev-kit
+	url = https://github.com/sandeepkesarkar/agent-dev-kit

--- a/.omnigent/config.yaml
+++ b/.omnigent/config.yaml
@@ -1,0 +1,1 @@
+default_agent: .agents/agent-dev-kit


### PR DESCRIPTION
## Summary
- Adds `agent-dev-kit` (https://github.com/sandeepkesarkar/agent-dev-kit) as a git submodule at `.agents/agent-dev-kit`, pinned to merge commit `59216dc` (agent-dev-kit's `main` tip at merge time) rather than tracking `main` — an explicit, reproducible initial pin. Bumping later is a deliberate `git submodule update --remote` + commit, per the submodule's own recommended workflow.
- Adds `.omnigent/config.yaml` at the fieldkit repo root with `default_agent: .agents/agent-dev-kit`, matching the exact key/shape documented in agent-dev-kit's `README.md` ("Agent bundles — pinned git submodule" section) and `docs/ARCHITECTURE.md`.

## Scope
- **In scope:** fieldkit-local wiring only (submodule + `.omnigent/config.yaml`).
- **Out of scope:** the machine-global `~/.agents/skills/` symlinks (handled separately, once, at the machine level) and `dev-infrastructure` (separate task/PR).
- **Orthogonal to spec-kit:** this is unrelated to fieldkit's existing `/speckit-*` multi-unit routing under `.specify/` (see `CLAUDE.md`). Nothing under `.specify/` or `CLAUDE.md` is touched by this change — the two systems (Omnigent agent bundles vs. spec-kit feature specs) are independent.

## Smoke test
Ran from fieldkit's repo root, against the submodule resolved via `.omnigent/config.yaml`'s `default_agent`:

1. `omnigent run` (interactive) — TUI banner correctly shows the resolved bundle:
   ```
   polly — A coding orchestrator that breaks your goal into pieces and…
   ~/src/fieldkit/.worktrees/wire-agent-dev-kit
   Try asking polly to spawn the following sub-agents!
   Claude → Subscription · Gemini → not configured · Codex → Subscription · Pi → no default → will use 🖥️ Ollama
   ```
2. Direct call to omnigent's own `omnigent.spec.parser.parse` + `omnigent.spec.validator.validate` against the resolved `default_agent` path (same verification method agent-dev-kit's own `docs/ARCHITECTURE.md` uses) — full, unambiguous enumeration:
   ```
   default_agent (from .omnigent/config.yaml): .agents/agent-dev-kit
   resolved path: .../fieldkit/.worktrees/wire-agent-dev-kit/.agents/agent-dev-kit
   is git submodule checkout: True

   Root agent bundle: name='polly' (Polly)
   Sub-agent bundles discovered (7):
     - agy          harness=antigravity-native
     - claude_code  harness=claude-native
     - codex        harness=codex
     - cursor       harness=cursor-native
     - hermes       harness=hermes-native
     - opencode     harness=opencode-native
     - pi           harness=pi

   All parsed and validated cleanly with no errors.
   ```

Confirms: Polly's root config resolves through the submodule, and all 7 documented sub-agent bundles (claude_code, codex, opencode, cursor, hermes, agy, pi) are discovered and validate cleanly.

## Test plan
- [x] Submodule added and pinned (`git submodule status` shows `59216dc2cdeb37958ed7018a7cd64e85288629db .agents/agent-dev-kit (heads/main)`)
- [x] `.omnigent/config.yaml` matches documented format exactly
- [x] `omnigent config list` from repo root shows the project-level `default_agent` override taking effect
- [x] `omnigent run` resolves and launches Polly
- [x] Direct spec parser/validator run confirms all 7 sub-agent bundles discovered and valid
- [x] Confirmed no changes under `.specify/` or to `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)