### PR TITLE
Fix pending_facebook_upload reprocessing loop (#34)

### DIFF
--- a/platform/photo-agent/SKILL_upload_facebook.md
+++ b/platform/photo-agent/SKILL_upload_facebook.md
@@ -59,16 +59,26 @@ python3 platform/photo-agent/scripts/upload_facebook.py --source cron
 
 ## Behavior
 
+0. Acquires `data/photo-agent/upload_facebook.lock` (non-blocking). If another instance is
+   already running — e.g. a slow upload from the previous minute's tick still in progress —
+   exits silently (0) without touching `facebook_state.json` at all. Held for the entire
+   duration of steps 1–8; released (and the OS also releases it automatically if the process
+   crashes) before exiting.
 1. Reads `data/photo-agent/facebook_state.json` for a `pending` or `uploading` job.
 2. If none → exits silently (0).
-3. Checks 60-second retry cooldown — exits silently if too soon.
+3. Atomically claims the job (staleness check, 60-second retry cooldown, attempt-budget check,
+   and the `uploading` status transition, all in one step) — exits silently if declined.
 4. Checks that the video file exists — marks `failed` if not.
-5. Marks status `uploading`, calls Facebook Graph API (`POST /{page_id}/videos`).
+5. Calls Facebook Graph API (`POST /{page_id}/videos`).
 6. On success: marks `published`, sends Telegram confirmation with the post URL.
-7. On `FacebookUploadError`: increments `attempt_count`; after 3 failures marks `failed`
-   and sends Telegram alert.
+7. On `FacebookUploadError`: below 3 attempts, releases the claim for a cooldown-gated retry;
+   on the 3rd failure marks `failed` and sends Telegram alert.
 8. On `FacebookTokenError` (token invalid/expired): marks `failed` immediately and
    sends Telegram alert to reconnect the Page.
+
+If `upload_facebook.lock` is ever left behind by a hard crash (kill -9, host power loss), it is
+harmless: `flock` releases automatically when the holding process dies, so the next cron tick
+acquires it normally. Nothing needs cleaning up manually.
 
 ---
 

--- a/platform/photo-agent/scripts/e2e_stage4_await_approval.py
+++ b/platform/photo-agent/scripts/e2e_stage4_await_approval.py
@@ -4,6 +4,12 @@ e2e_stage4_await_approval.py — E2E Stage 4: Wait for Telegram approval.
 Polls state.json and facebook_state.json until check_approval.py has cleared
 the pending_approval and enqueued a Facebook upload for this test run.
 
+A pending enqueue (facebook_state.get_pending_upload()) is one success signal,
+but not the only one: upload_facebook.py's cron leg can race ahead and publish
+the job — clearing pending_facebook_upload (issue #34) — before this poll ever
+samples the brief window it was pending in. facebook_state.find_published() is
+checked as a second, equally-valid success signal for exactly that race.
+
 Tap Approve in Telegram while this script is polling. If not using cron,
 run check_approval.py in another terminal to process the approval.
 
@@ -38,16 +44,20 @@ _POLL_INTERVAL = 10
 
 
 def _wait_for_approval(test_name: str, timeout: int) -> None:
-    """Poll until pending_approval is cleared and a matching FB upload is enqueued.
+    """Poll until pending_approval is cleared and a matching FB upload is enqueued (or has
+    already resolved — see module docstring).
 
     Raises SystemExit on timeout.
     """
     deadline = time.time() + timeout
     while time.time() < deadline:
         pending = state.get_pending_approval()
-        fb = facebook_state.get_pending_upload()
-        if pending is None and fb is not None and fb.get("project_name") == test_name:
-            return
+        if pending is None:
+            fb = facebook_state.get_pending_upload()
+            if fb is not None and fb.get("project_name") == test_name:
+                return
+            if facebook_state.find_published(test_name) is not None:
+                return
         time.sleep(_POLL_INTERVAL)
     raise SystemExit(f"Stage 4 timed out after {timeout}s waiting for approval of {test_name}")
 

--- a/platform/photo-agent/scripts/e2e_stage5_await_facebook.py
+++ b/platform/photo-agent/scripts/e2e_stage5_await_facebook.py
@@ -1,8 +1,16 @@
 """
 e2e_stage5_await_facebook.py — E2E Stage 5: Wait for Facebook upload to complete.
 
-Polls facebook_state.json until upload_facebook.py marks the job as 'published',
-then updates e2e_run_state.json with the fb_post_id.
+Polls facebook_state.json's published_history for this test's job, then
+updates e2e_run_state.json with the fb_post_id.
+
+published_history (not pending_facebook_upload) is the source of truth here:
+mark_published() clears pending_facebook_upload as soon as a job resolves
+(issue #34 — a cron entrypoint that keeps seeing a resolved job as pending
+reprocesses it forever), so a 'published' status is never observable on the
+pending record itself. facebook_state.find_published() searches the capped
+history by project_name, so an unrelated publish landing in between can't
+hide this run's own record.
 
 Run upload_facebook.py in another terminal while this polls, or wait for cron.
 
@@ -37,17 +45,15 @@ _POLL_INTERVAL = 10
 
 
 def _wait_for_facebook_post(test_name: str, timeout: int) -> str:
-    """Poll until upload_facebook.py marks the job as 'published'. Returns fb_post_id.
+    """Poll until upload_facebook.py publishes this test's job. Returns fb_post_id.
 
     Raises SystemExit on timeout.
     """
     deadline = time.time() + timeout
     while time.time() < deadline:
-        fb = facebook_state.get_pending_upload()
-        if (fb is not None
-                and fb.get("project_name") == test_name
-                and fb.get("status") == "published"):
-            return fb.get("fb_post_id", "")
+        found = facebook_state.find_published(test_name)
+        if found is not None:
+            return found.get("fb_post_id", "")
         time.sleep(_POLL_INTERVAL)
     raise SystemExit(f"Stage 5 timed out after {timeout}s waiting for Facebook post for {test_name}")
 

--- a/platform/photo-agent/scripts/upload_facebook.py
+++ b/platform/photo-agent/scripts/upload_facebook.py
@@ -9,10 +9,18 @@ Reads the pending VideoUploadJob from facebook_state.json, uploads the video
 to the linked Facebook Page via Graph API, and sends a Telegram confirmation.
 
 Retry and failure-recovery logic (US3):
-  - attempt_count/last_attempt_at are persisted BEFORE each Facebook API call
-    (not only after a failure), so a process killed mid-upload still leaves a
-    bounded, cooldown-gated trail instead of being retried immediately forever.
-  - Cooldown: if the last attempt was within 60 seconds, exits silently.
+  - Claiming (tools/facebook_state.py's claim_pending_upload()) is a single
+    atomic exclusive-lock transaction that checks staleness, cooldown, and the
+    attempt budget, and transitions the job to 'uploading' — all before this
+    script ever calls the Facebook API. That atomicity is what stops two
+    overlapping cron invocations (e.g. a slow upload still running when the
+    next minute's tick starts) from both claiming the same job and both
+    posting a real duplicate (issue #34 follow-up).
+  - attempt_count/last_attempt_at are persisted by the claim itself, BEFORE
+    the Facebook API call — not only after a failure — so a process killed
+    mid-upload still leaves a bounded, cooldown-gated trail instead of being
+    retried immediately forever.
+  - Cooldown: if the last attempt was within 60 seconds, the claim declines.
   - Retry limit: 3 attempts. After the 3rd failure, marks the job as failed
     and sends a Telegram alert.
   - Token expiry (FacebookTokenError): marks failed immediately after just
@@ -20,9 +28,10 @@ Retry and failure-recovery logic (US3):
     alerts the admin to reconnect the Page.
 
 A resolved job (published, or terminally failed) always clears
-pending_facebook_upload (see tools/facebook_state.py) — main() additionally
-double-checks this before ever reprocessing a job, so a stale or pre-fix
-state file can't cause a duplicate Facebook post (issue #34).
+pending_facebook_upload (see tools/facebook_state.py) — claim_pending_upload()
+additionally self-heals a stale or pre-fix state file (an already-published
+idempotency_key, or a status already 'failed', found still sitting in
+pending_facebook_upload) by clearing it instead of reprocessing (issue #34).
 
 FB_APP_SECRET is never read here (used only by generate_auth_link.py).
 """
@@ -31,7 +40,6 @@ import argparse
 import logging
 import os
 import sys
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -52,6 +60,13 @@ _log = logging.getLogger(__name__)
 
 _MAX_ATTEMPTS = 3
 _COOLDOWN_SECONDS = 60
+# How long a claim (status='uploading') is presumed still genuinely in-progress before
+# claim_pending_upload() treats it as an abandoned/crashed attempt and allows reclaiming it.
+# Deliberately much longer than _COOLDOWN_SECONDS and any realistic video upload duration for
+# these short social-media clips — a lease that expires while a legitimate upload is still
+# running would let a second cron tick reclaim and re-call the Facebook API for the same job.
+# See claim_pending_upload()'s docstring for the full tradeoff.
+_UPLOAD_LEASE_SECONDS = 900
 _REPO_ROOT = Path(__file__).parents[3]
 
 
@@ -113,78 +128,61 @@ def main(argv=None) -> None:
         _log.debug("no pending facebook upload — exiting")
         return
 
-    # Defense in depth: a resolved job (published, or terminally failed) must
-    # never reach _process_upload, which would call the Facebook API again for
-    # an already-published idempotency_key (real duplicate post) or spin the
-    # cron entrypoint forever on a job mark_failed already gave up on. This
-    # check is independent of facebook_state's own clearing on mark_published/
-    # mark_failed so it also self-heals a state file written before that fix.
-    idem_key = record.get("idempotency_key")
-    already_published = bool(idem_key) and facebook_state.is_published(idem_key)
-    already_terminal_failed = record.get("status") == "failed"
-    if already_published or already_terminal_failed:
-        _log.warning(
-            "stale pending facebook upload record found (published=%s failed=%s) "
-            "project=%s key=%s — clearing without reprocessing",
-            already_published, already_terminal_failed, record.get("project_name"), idem_key,
-        )
-        facebook_state.clear_pending_upload()
-        return
-
     _process_upload(record, page_token, page_id, chat_id)
 
 
 def _process_upload(record: dict, page_token: str, page_id: str, chat_id: str) -> None:
-    """Attempt to upload the video described by record. Handles retry cooldown and failures."""
+    """Claim and attempt to upload the video described by record.
+
+    record is only a snapshot (from main()'s get_pending_upload()) used here for its immutable
+    fields — project_name/video_local_path/page_id/idempotency_key never change across a
+    record's lifetime, only status/attempt_count/last_attempt_at/fb_post_id do. Every decision
+    about whether and how to proceed (staleness, cooldown, attempt budget, claiming) is made by
+    claim_pending_upload() against the CURRENT, freshly-locked state under one exclusive-lock
+    transaction — not by reasoning from this possibly-stale snapshot — so two overlapping
+    invocations of this script can never both observe an unclaimed job and both call the
+    Facebook API (issue #34 follow-up).
+    """
     project_name = record["project_name"]
     video_path = record["video_local_path"]
     idem_key = record["idempotency_key"]
-    attempt_count = record.get("attempt_count", 0)
-    last_attempt_at = record.get("last_attempt_at")
+    attempt_count = record.get("attempt_count", 0)  # pre-claim value; claim() advances it by 1
 
-    # Cooldown check: do not retry within 60 seconds of the last attempt.
-    if last_attempt_at is not None:
-        try:
-            last_dt = datetime.fromisoformat(last_attempt_at)
-            if datetime.now(timezone.utc) - last_dt < timedelta(seconds=_COOLDOWN_SECONDS):
-                _log.debug("cooldown not elapsed for project=%s — exiting", project_name)
-                return
-        except ValueError:
-            _log.warning("unparseable last_attempt_at=%r — proceeding", last_attempt_at)
+    claim = facebook_state.claim_pending_upload(
+        idem_key,
+        cooldown_seconds=_COOLDOWN_SECONDS,
+        max_attempts=_MAX_ATTEMPTS,
+        lease_seconds=_UPLOAD_LEASE_SECONDS,
+    )
 
-    # Video file must exist before we call the API.
-    if not Path(video_path).exists():
-        _log.error("video file missing: project=%s path=%s", project_name, video_path)
-        facebook_state.mark_failed(idem_key)
+    if claim in ("mismatch", "in_flight", "cooldown"):
+        _log.debug("declined claim (%s): project=%s key=%s", claim, project_name, idem_key)
         return
-
-    # Attempt budget check: exhausted BEFORE calling the API again, not only inside the
-    # FacebookUploadError handler below. attempt_count is persisted before every API call (see
-    # below), so this bound holds even if prior attempts never reached that handler at all —
-    # e.g. the process was killed mid-upload (OOM, host restart) rather than the API cleanly
-    # raising FacebookUploadError. Without this, a job stuck crashing every tick could retry
-    # forever at the cooldown's pace instead of ever stopping.
-    if attempt_count >= _MAX_ATTEMPTS:
-        _log.error("attempt budget exhausted: project=%s attempt_count=%d", project_name, attempt_count)
-        facebook_state.mark_failed(idem_key)
+    if claim in ("stale_published", "stale_failed"):
+        _log.warning(
+            "cleared stale pending record (%s) without reprocessing: project=%s key=%s",
+            claim, project_name, idem_key,
+        )
+        return
+    if claim == "exhausted":
+        _log.error("attempt budget exhausted: project=%s key=%s", project_name, idem_key)
         facebook_logger.log_upload_exhausted(project_name)
         _send_alert(
             chat_id,
             f"⚠️ Facebook upload failed for {project_name} after {_MAX_ATTEMPTS} attempts — check logs",
         )
         return
+    assert claim == "claimed", f"unexpected claim outcome: {claim!r}"
+
+    # Video file must exist before we call the API. Checked only after a successful claim — the
+    # claim is the single gate against a concurrent duplicate regardless of ordering here, and
+    # this way the filesystem is only ever touched for a job we've actually secured.
+    if not Path(video_path).exists():
+        _log.error("video file missing: project=%s path=%s", project_name, video_path)
+        facebook_state.mark_failed(idem_key)
+        return
 
     attempt_number = attempt_count + 1
-    facebook_state.mark_uploading(idem_key)
-    # Persist the attempt (attempt_count + last_attempt_at) BEFORE calling the API, not only on
-    # failure: if this process is killed mid-upload (OOM, host restart, cron timeout) after
-    # facebook_api.upload_video() has already created the real post but before mark_published()
-    # runs, the next tick must still see an advanced attempt_count and a fresh cooldown window —
-    # otherwise a crashed-but-actually-succeeded attempt would be retried immediately and forever
-    # (attempt_count frozen, cooldown never engaged), which is the same real-duplicate-post risk
-    # issue #34 was about. This bounds that residual window to _MAX_ATTEMPTS cooldown-spaced
-    # retries before mark_failed alerts the admin, instead of an unbounded retry loop.
-    facebook_state.increment_attempt(idem_key)
     facebook_logger.log_upload_started(project_name, attempt_number)
 
     try:
@@ -208,6 +206,11 @@ def _process_upload(record: dict, page_token: str, page_id: str, chat_id: str) -
                 chat_id,
                 f"⚠️ Facebook upload failed for {project_name} after {_MAX_ATTEMPTS} attempts — check logs",
             )
+        else:
+            # A KNOWN, caught failure with retries remaining: release the claim immediately so
+            # the next attempt is gated by the short _COOLDOWN_SECONDS, not the much longer
+            # _UPLOAD_LEASE_SECONDS a genuinely abandoned/crashed claim would otherwise wait out.
+            facebook_state.release_claim(idem_key)
         return
 
     # Success path.

--- a/platform/photo-agent/scripts/upload_facebook.py
+++ b/platform/photo-agent/scripts/upload_facebook.py
@@ -8,14 +8,25 @@ Usage:
 Reads the pending VideoUploadJob from facebook_state.json, uploads the video
 to the linked Facebook Page via Graph API, and sends a Telegram confirmation.
 
+Cron re-entrancy lock (issue #34 follow-up): upload_facebook.lock, acquired
+non-blocking and held for the ENTIRE duration of processing a claimed job —
+mirrors check_approval.py's _try_acquire_check_lock. This is the actual
+guarantee against two overlapping cron invocations both calling the Facebook
+API for the same job: a lease-timeout-based reclaim alone (see
+claim_pending_upload()) cannot distinguish a crashed holder from a merely
+slow-but-still-live one — flock is what can, since the OS releases it
+automatically on process death but never on a process that's simply still
+running. A second invocation that can't acquire this lock exits immediately,
+before ever touching facebook_state.
+
 Retry and failure-recovery logic (US3):
   - Claiming (tools/facebook_state.py's claim_pending_upload()) is a single
     atomic exclusive-lock transaction that checks staleness, cooldown, and the
     attempt budget, and transitions the job to 'uploading' — all before this
-    script ever calls the Facebook API. That atomicity is what stops two
-    overlapping cron invocations (e.g. a slow upload still running when the
-    next minute's tick starts) from both claiming the same job and both
-    posting a real duplicate (issue #34 follow-up).
+    script ever calls the Facebook API. Combined with the re-entrancy lock
+    above, this is what stops two overlapping cron invocations (e.g. a slow
+    upload still running when the next minute's tick starts) from both
+    claiming the same job and both posting a real duplicate (issue #34).
   - attempt_count/last_attempt_at are persisted by the claim itself, BEFORE
     the Facebook API call — not only after a failure — so a process killed
     mid-upload still leaves a bounded, cooldown-gated trail instead of being
@@ -37,6 +48,7 @@ FB_APP_SECRET is never read here (used only by generate_auth_link.py).
 """
 
 import argparse
+import fcntl
 import logging
 import os
 import sys
@@ -68,6 +80,29 @@ _COOLDOWN_SECONDS = 60
 # See claim_pending_upload()'s docstring for the full tradeoff.
 _UPLOAD_LEASE_SECONDS = 900
 _REPO_ROOT = Path(__file__).parents[3]
+
+
+def _try_acquire_upload_lock() -> "IO | None":
+    """Try to acquire upload_facebook.lock exclusively (non-blocking).
+
+    Mirrors check_approval.py's _try_acquire_check_lock: this is the actual mutual-exclusion
+    guarantee for a claimed job's ENTIRE processing (claim through mark_published/mark_failed/
+    release_claim), not just the state-file transitions in between — see the module docstring
+    for why the lease-timeout reclaim in claim_pending_upload() cannot substitute for this.
+
+    Returns the open lock file object on success, or None if another upload_facebook instance
+    is already running. The caller must close the returned file object to release the lock.
+    """
+    data_dir = Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = data_dir / "upload_facebook.lock"
+    f = open(lock_path, "w")
+    try:
+        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return f
+    except BlockingIOError:
+        f.close()
+        return None
 
 
 def _get_tmp_root() -> Path:
@@ -123,12 +158,20 @@ def main(argv=None) -> None:
         _log.error("FB_PAGE_ACCESS_TOKEN and FB_PAGE_ID are required")
         sys.exit(1)
 
-    record = facebook_state.get_pending_upload()
-    if record is None:
-        _log.debug("no pending facebook upload — exiting")
+    lock_f = _try_acquire_upload_lock()
+    if lock_f is None:
+        _log.debug("another upload_facebook instance is running — exiting")
         return
+    try:
+        record = facebook_state.get_pending_upload()
+        if record is None:
+            _log.debug("no pending facebook upload — exiting")
+            return
 
-    _process_upload(record, page_token, page_id, chat_id)
+        _process_upload(record, page_token, page_id, chat_id)
+    finally:
+        fcntl.flock(lock_f, fcntl.LOCK_UN)
+        lock_f.close()
 
 
 def _process_upload(record: dict, page_token: str, page_id: str, chat_id: str) -> None:

--- a/platform/photo-agent/scripts/upload_facebook.py
+++ b/platform/photo-agent/scripts/upload_facebook.py
@@ -9,11 +9,20 @@ Reads the pending VideoUploadJob from facebook_state.json, uploads the video
 to the linked Facebook Page via Graph API, and sends a Telegram confirmation.
 
 Retry and failure-recovery logic (US3):
+  - attempt_count/last_attempt_at are persisted BEFORE each Facebook API call
+    (not only after a failure), so a process killed mid-upload still leaves a
+    bounded, cooldown-gated trail instead of being retried immediately forever.
   - Cooldown: if the last attempt was within 60 seconds, exits silently.
   - Retry limit: 3 attempts. After the 3rd failure, marks the job as failed
     and sends a Telegram alert.
-  - Token expiry (FacebookTokenError): skips the retry budget entirely, marks
-    failed immediately, and alerts the admin to reconnect the Page.
+  - Token expiry (FacebookTokenError): marks failed immediately after just
+    this one attempt (does not wait for the retry budget to exhaust), and
+    alerts the admin to reconnect the Page.
+
+A resolved job (published, or terminally failed) always clears
+pending_facebook_upload (see tools/facebook_state.py) — main() additionally
+double-checks this before ever reprocessing a job, so a stale or pre-fix
+state file can't cause a duplicate Facebook post (issue #34).
 
 FB_APP_SECRET is never read here (used only by generate_auth_link.py).
 """
@@ -104,6 +113,24 @@ def main(argv=None) -> None:
         _log.debug("no pending facebook upload — exiting")
         return
 
+    # Defense in depth: a resolved job (published, or terminally failed) must
+    # never reach _process_upload, which would call the Facebook API again for
+    # an already-published idempotency_key (real duplicate post) or spin the
+    # cron entrypoint forever on a job mark_failed already gave up on. This
+    # check is independent of facebook_state's own clearing on mark_published/
+    # mark_failed so it also self-heals a state file written before that fix.
+    idem_key = record.get("idempotency_key")
+    already_published = bool(idem_key) and facebook_state.is_published(idem_key)
+    already_terminal_failed = record.get("status") == "failed"
+    if already_published or already_terminal_failed:
+        _log.warning(
+            "stale pending facebook upload record found (published=%s failed=%s) "
+            "project=%s key=%s — clearing without reprocessing",
+            already_published, already_terminal_failed, record.get("project_name"), idem_key,
+        )
+        facebook_state.clear_pending_upload()
+        return
+
     _process_upload(record, page_token, page_id, chat_id)
 
 
@@ -131,8 +158,33 @@ def _process_upload(record: dict, page_token: str, page_id: str, chat_id: str) -
         facebook_state.mark_failed(idem_key)
         return
 
+    # Attempt budget check: exhausted BEFORE calling the API again, not only inside the
+    # FacebookUploadError handler below. attempt_count is persisted before every API call (see
+    # below), so this bound holds even if prior attempts never reached that handler at all —
+    # e.g. the process was killed mid-upload (OOM, host restart) rather than the API cleanly
+    # raising FacebookUploadError. Without this, a job stuck crashing every tick could retry
+    # forever at the cooldown's pace instead of ever stopping.
+    if attempt_count >= _MAX_ATTEMPTS:
+        _log.error("attempt budget exhausted: project=%s attempt_count=%d", project_name, attempt_count)
+        facebook_state.mark_failed(idem_key)
+        facebook_logger.log_upload_exhausted(project_name)
+        _send_alert(
+            chat_id,
+            f"⚠️ Facebook upload failed for {project_name} after {_MAX_ATTEMPTS} attempts — check logs",
+        )
+        return
+
     attempt_number = attempt_count + 1
     facebook_state.mark_uploading(idem_key)
+    # Persist the attempt (attempt_count + last_attempt_at) BEFORE calling the API, not only on
+    # failure: if this process is killed mid-upload (OOM, host restart, cron timeout) after
+    # facebook_api.upload_video() has already created the real post but before mark_published()
+    # runs, the next tick must still see an advanced attempt_count and a fresh cooldown window —
+    # otherwise a crashed-but-actually-succeeded attempt would be retried immediately and forever
+    # (attempt_count frozen, cooldown never engaged), which is the same real-duplicate-post risk
+    # issue #34 was about. This bounds that residual window to _MAX_ATTEMPTS cooldown-spaced
+    # retries before mark_failed alerts the admin, instead of an unbounded retry loop.
+    facebook_state.increment_attempt(idem_key)
     facebook_logger.log_upload_started(project_name, attempt_number)
 
     try:
@@ -148,10 +200,8 @@ def _process_upload(record: dict, page_token: str, page_id: str, chat_id: str) -
         return
     except FacebookUploadError as exc:
         _log.error("upload failed: project=%s attempt=%d: %s", project_name, attempt_number, exc)
-        facebook_state.increment_attempt(idem_key)
         facebook_logger.log_upload_attempt_failed(project_name, attempt_number, str(exc))
-        new_count = attempt_count + 1
-        if new_count >= _MAX_ATTEMPTS:
+        if attempt_number >= _MAX_ATTEMPTS:
             facebook_state.mark_failed(idem_key)
             facebook_logger.log_upload_exhausted(project_name)
             _send_alert(

--- a/platform/photo-agent/tests/test_facebook_state.py
+++ b/platform/photo-agent/tests/test_facebook_state.py
@@ -2,9 +2,11 @@
 Tests for tools/facebook_state.py — the Facebook upload state manager.
 
 Covers: set_pending_upload (success, missing keys, idempotency check),
-get_pending_upload, mark_uploading, mark_published, mark_failed,
-increment_attempt, is_published, fcntl exclusive locking, and FIELDKIT_DATA_DIR
-env override.
+get_pending_upload, claim_pending_upload (including the concurrent-claim
+regression for issue #34's check/use race), clear_pending_upload
+(compare-and-clear, including the exact stale-clear-destroys-a-newer-job
+regression), mark_published, find_published, mark_failed, is_published,
+fcntl exclusive locking, and FIELDKIT_DATA_DIR env override.
 """
 
 import json
@@ -128,23 +130,276 @@ def test_set_pending_upload_preserves_published_keys(valid_record):
     assert "100" in data["published_idempotency_keys"]
 
 
-# --- mark_uploading ---
+# --- claim_pending_upload ---
 
-def test_mark_uploading_sets_status(valid_record):
-    """mark_uploading() transitions the pending record's status to 'uploading'."""
+def test_claim_pending_upload_claims_a_fresh_job(valid_record):
+    """claim_pending_upload() transitions a fresh job to 'uploading' and advances
+    attempt_count/last_attempt_at, all as part of the single 'claimed' transaction."""
     fb_state.set_pending_upload(valid_record)
-    fb_state.mark_uploading(valid_record["idempotency_key"])
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "claimed"
     record = fb_state.get_pending_upload()
     assert record["status"] == "uploading"
+    assert record["attempt_count"] == 1
+    assert record["last_attempt_at"] is not None
+    from datetime import datetime
+    datetime.fromisoformat(record["last_attempt_at"])
 
 
-def test_mark_uploading_preserves_other_fields(valid_record):
-    """mark_uploading() does not alter fields other than status."""
+def test_claim_pending_upload_preserves_other_fields(valid_record):
+    """claim_pending_upload() does not alter fields other than status/attempt_count/last_attempt_at."""
     fb_state.set_pending_upload(valid_record)
-    fb_state.mark_uploading(valid_record["idempotency_key"])
+    fb_state.claim_pending_upload(valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900)
     record = fb_state.get_pending_upload()
     assert record["project_name"] == valid_record["project_name"]
     assert record["idempotency_key"] == valid_record["idempotency_key"]
+
+
+def test_claim_pending_upload_mismatch_when_nothing_pending():
+    """claim_pending_upload() returns 'mismatch' when there is no pending record at all."""
+    assert fb_state.claim_pending_upload("some_key", cooldown_seconds=60, max_attempts=3, lease_seconds=900) == "mismatch"
+
+
+def test_claim_pending_upload_mismatch_when_key_differs(valid_record):
+    """claim_pending_upload() returns 'mismatch' (and does not touch state) if the current
+    pending record's idempotency_key differs from the one the caller expects — e.g. the caller's
+    snapshot is stale because the job already resolved and a different job was enqueued."""
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload("some_other_key", cooldown_seconds=60, max_attempts=3, lease_seconds=900)
+    assert result == "mismatch"
+    assert fb_state.get_pending_upload() == valid_record
+
+
+def test_claim_pending_upload_in_flight_when_already_uploading(valid_record):
+    """claim_pending_upload() declines ('in_flight') a job whose status is already 'uploading'
+    and whose lease hasn't expired — this is the actual fix for issue #34's check/use race: a
+    second overlapping invocation must not be able to claim a job another still-running
+    invocation already claimed."""
+    from datetime import datetime, timedelta, timezone
+    recent = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
+    valid_record["status"] = "uploading"
+    valid_record["last_attempt_at"] = recent
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "in_flight"
+    record = fb_state.get_pending_upload()
+    assert record["attempt_count"] == 0  # untouched — not double-counted
+
+
+def test_claim_pending_upload_reclaims_after_lease_expires(valid_record):
+    """A claim stuck at status='uploading' (e.g. the claiming process crashed without calling
+    release_claim()/mark_published()/mark_failed()) becomes reclaimable once lease_seconds has
+    elapsed — otherwise a crashed process would wedge the job at 'in_flight' forever, never
+    retried and never alerting anyone. Reclaiming is still gated by the normal attempt budget.
+    """
+    from datetime import datetime, timedelta, timezone
+    old = (datetime.now(timezone.utc) - timedelta(seconds=1000)).isoformat()
+    valid_record["status"] = "uploading"
+    valid_record["attempt_count"] = 1
+    valid_record["last_attempt_at"] = old
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "claimed"
+    record = fb_state.get_pending_upload()
+    assert record["attempt_count"] == 2
+
+
+def test_claim_pending_upload_lease_expired_but_exhausted_clears(valid_record):
+    """A crashed claim whose lease has expired AND whose attempt_count is already at the cap is
+    cleared as exhausted, not reclaimed — the lease only re-opens the normal attempt-budget path,
+    it doesn't grant extra retries."""
+    from datetime import datetime, timedelta, timezone
+    old = (datetime.now(timezone.utc) - timedelta(seconds=1000)).isoformat()
+    valid_record["status"] = "uploading"
+    valid_record["attempt_count"] = 3
+    valid_record["last_attempt_at"] = old
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "exhausted"
+    assert fb_state.get_pending_upload() is None
+
+
+# --- release_claim ---
+
+def test_release_claim_resets_status_to_pending(valid_record):
+    """release_claim() resets status back to 'pending' after a claim, without touching
+    attempt_count/last_attempt_at, so the next claim_pending_upload() call is gated by the
+    short cooldown rather than the long abandoned-claim lease."""
+    fb_state.set_pending_upload(valid_record)
+    fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    fb_state.release_claim(valid_record["idempotency_key"])
+    record = fb_state.get_pending_upload()
+    assert record["status"] == "pending"
+    assert record["attempt_count"] == 1
+
+
+def test_release_claim_does_not_destroy_a_newer_job(valid_record):
+    """release_claim() is compare-and-update: a stale caller must not reset a DIFFERENT, newer
+    job's status."""
+    fb_state.set_pending_upload(valid_record)
+    fb_state.mark_published(valid_record["idempotency_key"], "fb_post_A")
+
+    job_b = dict(valid_record, project_name="job_b", idempotency_key="99")
+    fb_state.set_pending_upload(job_b)
+
+    fb_state.release_claim(valid_record["idempotency_key"])  # stale caller, A's key
+
+    assert fb_state.get_pending_upload() == job_b
+
+
+def test_claim_pending_upload_concurrent_calls_only_one_claims(valid_record):
+    """Two overlapping claim_pending_upload() calls for the SAME job must not both succeed.
+
+    This directly reproduces the issue #34 follow-up finding: two overlapping cron invocations
+    (e.g. a slow upload still running when the next minute's tick starts) could otherwise both
+    observe an unclaimed job and both call the Facebook API — a real duplicate post. The fix is
+    that the read + staleness check + status transition all happen under ONE exclusive-lock
+    acquisition, so the second concurrent caller's read-modify-write sees the FIRST caller's
+    already-'uploading' status, not a stale earlier snapshot.
+    """
+    fb_state.set_pending_upload(valid_record)
+    results = []
+    barrier = threading.Barrier(2)
+
+    def do_claim():
+        barrier.wait()
+        results.append(fb_state.claim_pending_upload(
+            valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+        ))
+
+    threads = [threading.Thread(target=do_claim) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sorted(results) == ["claimed", "in_flight"]
+    record = fb_state.get_pending_upload()
+    assert record["attempt_count"] == 1  # only the winning claim advanced it
+
+
+def test_claim_pending_upload_cooldown_blocks_recent_attempt(valid_record):
+    """claim_pending_upload() declines ('cooldown') and does not touch state if the last attempt
+    was within cooldown_seconds."""
+    from datetime import datetime, timedelta, timezone
+    recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+    valid_record["attempt_count"] = 1
+    valid_record["last_attempt_at"] = recent
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "cooldown"
+    assert fb_state.get_pending_upload()["attempt_count"] == 1
+
+
+def test_claim_pending_upload_proceeds_after_cooldown_elapsed(valid_record):
+    """claim_pending_upload() claims successfully once cooldown_seconds has elapsed."""
+    from datetime import datetime, timedelta, timezone
+    old = (datetime.now(timezone.utc) - timedelta(seconds=90)).isoformat()
+    valid_record["attempt_count"] = 1
+    valid_record["last_attempt_at"] = old
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "claimed"
+    assert fb_state.get_pending_upload()["attempt_count"] == 2
+
+
+def test_claim_pending_upload_unparseable_last_attempt_at_proceeds(valid_record):
+    """claim_pending_upload() treats an unparseable last_attempt_at as if cooldown had elapsed."""
+    valid_record["attempt_count"] = 1
+    valid_record["last_attempt_at"] = "not-a-real-timestamp"
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "claimed"
+
+
+def test_claim_pending_upload_stale_published_clears(valid_record):
+    """claim_pending_upload() returns 'stale_published' and clears the pending slot if the
+    idempotency_key is already in published_idempotency_keys — self-healing a stale/pre-fix
+    state file instead of ever calling the Facebook API again for it."""
+    fb_state.STATE_FILE.write_text(json.dumps({
+        "pending_facebook_upload": valid_record,
+        "published_idempotency_keys": [valid_record["idempotency_key"]],
+    }))
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "stale_published"
+    assert fb_state.get_pending_upload() is None
+
+
+def test_claim_pending_upload_stale_failed_clears(valid_record):
+    """claim_pending_upload() returns 'stale_failed' and clears the pending slot if status is
+    already 'failed'."""
+    valid_record["status"] = "failed"
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "stale_failed"
+    assert fb_state.get_pending_upload() is None
+
+
+def test_claim_pending_upload_exhausted_clears(valid_record):
+    """claim_pending_upload() returns 'exhausted' and clears the pending slot if attempt_count
+    already reached max_attempts — no further claim is ever handed out for it."""
+    valid_record["attempt_count"] = 3
+    fb_state.set_pending_upload(valid_record)
+    result = fb_state.claim_pending_upload(
+        valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+    )
+    assert result == "exhausted"
+    assert fb_state.get_pending_upload() is None
+
+
+# --- clear_pending_upload ---
+
+def test_clear_pending_upload_clears_when_key_matches(valid_record):
+    """clear_pending_upload() clears the pending slot when the expected key still matches."""
+    fb_state.set_pending_upload(valid_record)
+    cleared = fb_state.clear_pending_upload(valid_record["idempotency_key"])
+    assert cleared is True
+    assert fb_state.get_pending_upload() is None
+
+
+def test_clear_pending_upload_noop_when_nothing_pending():
+    """clear_pending_upload() returns False and does nothing when there is no pending record."""
+    assert fb_state.clear_pending_upload("some_key") is False
+
+
+def test_clear_pending_upload_does_not_destroy_a_newer_job(valid_record):
+    """Compare-and-clear regression (issue #34 follow-up): a caller holding an earlier
+    snapshot's idempotency_key must not be able to destroy a DIFFERENT, newer job that's since
+    taken the pending slot's place.
+
+    Reproduces the exact interleaving: job A resolves (mark_published clears pending), a new
+    job B is enqueued, and only THEN does a stale caller try to clear using A's key.
+    """
+    fb_state.set_pending_upload(valid_record)  # job A
+    fb_state.mark_published(valid_record["idempotency_key"], "fb_post_A")  # pending now null
+
+    job_b = dict(valid_record, project_name="job_b", idempotency_key="99")
+    fb_state.set_pending_upload(job_b)  # a NEW job B takes the pending slot
+
+    cleared = fb_state.clear_pending_upload(valid_record["idempotency_key"])  # stale caller, A's key
+
+    assert cleared is False
+    assert fb_state.get_pending_upload() == job_b  # B survives untouched
 
 
 # --- mark_published ---
@@ -257,31 +512,18 @@ def test_mark_failed_clears_pending_upload(valid_record):
     assert fb_state.get_pending_upload() is None
 
 
-# --- increment_attempt ---
-
-def test_increment_attempt_increments_count(valid_record):
-    """increment_attempt() increments attempt_count by 1."""
+def test_mark_failed_does_not_destroy_a_newer_job(valid_record):
+    """mark_failed() is also compare-and-update (via _update_pending): a stale caller acting on
+    an old idempotency_key must not clear a different, newer job enqueued in its place."""
     fb_state.set_pending_upload(valid_record)
-    fb_state.increment_attempt(valid_record["idempotency_key"])
-    assert fb_state.get_pending_upload()["attempt_count"] == 1
+    fb_state.mark_published(valid_record["idempotency_key"], "fb_post_A")
 
+    job_b = dict(valid_record, project_name="job_b", idempotency_key="99")
+    fb_state.set_pending_upload(job_b)
 
-def test_increment_attempt_sets_last_attempt_at(valid_record):
-    """increment_attempt() sets last_attempt_at to a non-null ISO-8601 string."""
-    fb_state.set_pending_upload(valid_record)
-    fb_state.increment_attempt(valid_record["idempotency_key"])
-    record = fb_state.get_pending_upload()
-    assert record["last_attempt_at"] is not None
-    from datetime import datetime
-    datetime.fromisoformat(record["last_attempt_at"])
+    fb_state.mark_failed(valid_record["idempotency_key"])  # stale caller, A's key
 
-
-def test_increment_attempt_twice_accumulates(valid_record):
-    """Calling increment_attempt() twice yields attempt_count == 2."""
-    fb_state.set_pending_upload(valid_record)
-    fb_state.increment_attempt(valid_record["idempotency_key"])
-    fb_state.increment_attempt(valid_record["idempotency_key"])
-    assert fb_state.get_pending_upload()["attempt_count"] == 2
+    assert fb_state.get_pending_upload() == job_b
 
 
 # --- is_published ---
@@ -323,7 +565,7 @@ def test_is_published_true_after_mark_published(valid_record):
 # --- fcntl exclusive locking ---
 
 def test_concurrent_read_write_does_not_corrupt(valid_record):
-    """Concurrent get_pending_upload and increment_attempt leave the state file valid."""
+    """Concurrent get_pending_upload and claim_pending_upload leave the state file valid."""
     fb_state.set_pending_upload(valid_record)
     errors = []
 
@@ -335,7 +577,9 @@ def test_concurrent_read_write_does_not_corrupt(valid_record):
 
     def do_write():
         try:
-            fb_state.increment_attempt(valid_record["idempotency_key"])
+            fb_state.claim_pending_upload(
+                valid_record["idempotency_key"], cooldown_seconds=60, max_attempts=3, lease_seconds=900
+            )
         except Exception as exc:
             errors.append(exc)
 

--- a/platform/photo-agent/tests/test_facebook_state.py
+++ b/platform/photo-agent/tests/test_facebook_state.py
@@ -149,13 +149,18 @@ def test_mark_uploading_preserves_other_fields(valid_record):
 
 # --- mark_published ---
 
-def test_mark_published_sets_status_and_post_id(valid_record):
-    """mark_published() sets status=published and stores fb_post_id."""
+def test_mark_published_clears_pending_upload(valid_record):
+    """mark_published() clears pending_facebook_upload back to null (issue #34 regression).
+
+    Before this fix, the pending record was never cleared after a successful
+    publish, so get_pending_upload() kept returning the same resolved job on
+    every subsequent cron tick — see test_upload_facebook.py's
+    test_reprocessing_after_publish_does_not_call_upload_video for the
+    end-to-end reprocessing-loop regression this closes.
+    """
     fb_state.set_pending_upload(valid_record)
     fb_state.mark_published(valid_record["idempotency_key"], "fb_post_999")
-    record = fb_state.get_pending_upload()
-    assert record["status"] == "published"
-    assert record["fb_post_id"] == "fb_post_999"
+    assert fb_state.get_pending_upload() is None
 
 
 def test_mark_published_adds_key_to_published_list(valid_record):
@@ -180,23 +185,76 @@ def test_mark_published_appends_to_existing_keys(valid_record):
     assert valid_record["idempotency_key"] in data["published_idempotency_keys"]
 
 
+# --- find_published ---
+
+def test_find_published_returns_none_when_nothing_published():
+    """find_published() returns None when no job has ever been published."""
+    assert fb_state.find_published("some_project") is None
+
+
+def test_find_published_returns_project_and_post_id(valid_record):
+    """find_published() reflects a mark_published() call for that project_name.
+
+    Callers that need to observe a publish's outcome (e.g. the e2e test rig's
+    Stage 5, scripts/e2e_stage5_await_facebook.py) must use this instead of
+    polling get_pending_upload(), since mark_published() clears the pending
+    record as soon as the job resolves (issue #34).
+    """
+    fb_state.set_pending_upload(valid_record)
+    fb_state.mark_published(valid_record["idempotency_key"], "fb_post_999")
+    found = fb_state.find_published(valid_record["project_name"])
+    assert found["project_name"] == valid_record["project_name"]
+    assert found["idempotency_key"] == valid_record["idempotency_key"]
+    assert found["fb_post_id"] == "fb_post_999"
+
+
+def test_find_published_ignores_a_different_projects_publish(valid_record):
+    """find_published() only matches its own project_name, not whatever published most recently.
+
+    A single overwritable 'last published' slot would let an unrelated publish landing in
+    between hide an earlier one a caller is still polling for — published_history is a capped
+    list precisely so find_published() can search by project_name instead.
+    """
+    fb_state.set_pending_upload(valid_record)
+    fb_state.mark_published(valid_record["idempotency_key"], "fb_post_first")
+
+    second_record = dict(valid_record, project_name="second_project", idempotency_key="99")
+    fb_state.set_pending_upload(second_record)
+    fb_state.mark_published("99", "fb_post_second")
+
+    found = fb_state.find_published(valid_record["project_name"])
+    assert found["fb_post_id"] == "fb_post_first"
+    assert fb_state.find_published("second_project")["fb_post_id"] == "fb_post_second"
+    assert fb_state.find_published("no_such_project") is None
+
+
+def test_mark_published_caps_published_history(valid_record):
+    """mark_published() trims published_history to _PUBLISH_HISTORY_LIMIT entries."""
+    for i in range(fb_state._PUBLISH_HISTORY_LIMIT + 5):
+        record = dict(valid_record, project_name=f"project_{i}", idempotency_key=str(i))
+        fb_state.set_pending_upload(record)
+        fb_state.mark_published(str(i), f"fb_post_{i}")
+
+    data = json.loads(fb_state.STATE_FILE.read_text())
+    assert len(data["published_history"]) == fb_state._PUBLISH_HISTORY_LIMIT
+    # oldest entries were trimmed; the most recent ones survive
+    assert fb_state.find_published("project_0") is None
+    assert fb_state.find_published(f"project_{fb_state._PUBLISH_HISTORY_LIMIT + 4}") is not None
+
+
 # --- mark_failed ---
 
-def test_mark_failed_sets_status(valid_record):
-    """mark_failed() transitions status to 'failed'."""
-    fb_state.set_pending_upload(valid_record)
-    fb_state.mark_failed(valid_record["idempotency_key"])
-    record = fb_state.get_pending_upload()
-    assert record["status"] == "failed"
+def test_mark_failed_clears_pending_upload(valid_record):
+    """mark_failed() clears pending_facebook_upload back to null (issue #34 regression).
 
-
-def test_mark_failed_preserves_attempt_count(valid_record):
-    """mark_failed() does not reset attempt_count."""
+    Every call site treats mark_failed as terminal (no further retries follow
+    it). Before this fix, a terminally-failed job kept being reprocessed by
+    the cron entrypoint forever with no backoff.
+    """
     valid_record["attempt_count"] = 2
     fb_state.set_pending_upload(valid_record)
     fb_state.mark_failed(valid_record["idempotency_key"])
-    record = fb_state.get_pending_upload()
-    assert record["attempt_count"] == 2
+    assert fb_state.get_pending_upload() is None
 
 
 # --- increment_attempt ---

--- a/platform/photo-agent/tests/test_run_e2e_test.py
+++ b/platform/photo-agent/tests/test_run_e2e_test.py
@@ -306,6 +306,24 @@ def test_wait_for_approval_returns_when_approval_cleared(mocker):
     mocker.patch.object(stage4.state, "get_pending_approval", return_value=None)
     mocker.patch.object(stage4.facebook_state, "get_pending_upload",
                         return_value={"project_name": "e2e-test-20260620-143000", "status": "pending"})
+    mocker.patch.object(stage4.facebook_state, "find_published", return_value=None)
+    mocker.patch("scripts.e2e_stage4_await_approval.time.sleep")
+    _wait_for_approval("e2e-test-20260620-143000", timeout=60)  # must not raise
+
+
+def test_wait_for_approval_returns_when_job_already_published(mocker):
+    """_wait_for_approval also returns if the job resolved before this poll ever saw it pending.
+
+    Reproduces the race the issue #34 fix introduced: mark_published() now clears
+    pending_facebook_upload as soon as a job resolves, so upload_facebook.py's cron leg can
+    race ahead of this poll and publish (clearing pending) before it's ever observed pending.
+    find_published() is the fallback success signal for exactly that race.
+    """
+    import scripts.e2e_stage4_await_approval as stage4
+    mocker.patch.object(stage4.state, "get_pending_approval", return_value=None)
+    mocker.patch.object(stage4.facebook_state, "get_pending_upload", return_value=None)
+    mocker.patch.object(stage4.facebook_state, "find_published",
+                        return_value={"project_name": "e2e-test-20260620-143000", "fb_post_id": "post_abc"})
     mocker.patch("scripts.e2e_stage4_await_approval.time.sleep")
     _wait_for_approval("e2e-test-20260620-143000", timeout=60)  # must not raise
 
@@ -316,6 +334,7 @@ def test_wait_for_approval_exits_on_timeout(mocker):
     mocker.patch.object(stage4.state, "get_pending_approval",
                         return_value={"project_name": "e2e-test-20260620-143000"})
     mocker.patch.object(stage4.facebook_state, "get_pending_upload", return_value=None)
+    mocker.patch.object(stage4.facebook_state, "find_published", return_value=None)
     mocker.patch("scripts.e2e_stage4_await_approval.time.sleep")
     mocker.patch("scripts.e2e_stage4_await_approval.time.time", side_effect=[0, 0, 70])
     with pytest.raises((SystemExit, RuntimeError)):
@@ -323,11 +342,16 @@ def test_wait_for_approval_exits_on_timeout(mocker):
 
 
 def test_wait_for_facebook_post_returns_post_id_on_success(mocker):
-    """_wait_for_facebook_post returns the post_id when status becomes 'published'."""
+    """_wait_for_facebook_post returns the post_id once find_published matches the test name.
+
+    Polls published_history (via find_published) rather than pending_facebook_upload:
+    mark_published() clears the pending record as soon as a job resolves (issue #34), so
+    'published' is never observable on the pending record itself.
+    """
     import scripts.e2e_stage5_await_facebook as stage5
-    mocker.patch.object(stage5.facebook_state, "get_pending_upload",
+    mocker.patch.object(stage5.facebook_state, "find_published",
                         return_value={"project_name": "e2e-test-20260620-143000",
-                                      "status": "published", "fb_post_id": "post_abc"})
+                                      "fb_post_id": "post_abc"})
     mocker.patch("scripts.e2e_stage5_await_facebook.time.sleep")
     result = _wait_for_facebook_post("e2e-test-20260620-143000", timeout=60)
     assert result == "post_abc"
@@ -336,9 +360,7 @@ def test_wait_for_facebook_post_returns_post_id_on_success(mocker):
 def test_wait_for_facebook_post_exits_on_timeout(mocker):
     """_wait_for_facebook_post raises SystemExit (or RuntimeError) when timeout elapses."""
     import scripts.e2e_stage5_await_facebook as stage5
-    mocker.patch.object(stage5.facebook_state, "get_pending_upload",
-                        return_value={"project_name": "e2e-test-20260620-143000",
-                                      "status": "pending", "fb_post_id": None})
+    mocker.patch.object(stage5.facebook_state, "find_published", return_value=None)
     mocker.patch("scripts.e2e_stage5_await_facebook.time.sleep")
     mocker.patch("scripts.e2e_stage5_await_facebook.time.time", side_effect=[0, 0, 70])
     with pytest.raises((SystemExit, RuntimeError)):

--- a/platform/photo-agent/tests/test_upload_facebook.py
+++ b/platform/photo-agent/tests/test_upload_facebook.py
@@ -17,7 +17,6 @@ Only facebook_api/facebook_logger/telegram_api stay mocked there.
 """
 
 import json
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import ANY
 
@@ -56,15 +55,23 @@ def env(monkeypatch):
 
 @pytest.fixture
 def base(mocker, env):
-    """Common mocks for upload_facebook tests. Default: no pending job."""
+    """Common mocks for upload_facebook tests. Default: no pending job.
+
+    claim_pending_upload defaults to 'claimed' — irrelevant to tests where get_pending_upload
+    returns None (main() returns before _process_upload is ever reached), and the right default
+    for tests that DO set a pending record and want to exercise the upload attempt itself.
+    Override claim_pending_upload's return_value/side_effect directly to test the other claim
+    outcomes (mismatch/in_flight/cooldown/stale_published/stale_failed/exhausted) — that
+    decision logic lives in facebook_state.claim_pending_upload() and is covered directly in
+    test_facebook_state.py; these tests only need to verify upload_facebook.py's own dispatch on
+    each outcome.
+    """
     import scripts.upload_facebook as uf
     mocker.patch.object(uf.facebook_state, "get_pending_upload", return_value=None)
-    mocker.patch.object(uf.facebook_state, "mark_uploading")
+    mocker.patch.object(uf.facebook_state, "claim_pending_upload", return_value="claimed")
+    mocker.patch.object(uf.facebook_state, "release_claim")
     mocker.patch.object(uf.facebook_state, "mark_published")
     mocker.patch.object(uf.facebook_state, "mark_failed")
-    mocker.patch.object(uf.facebook_state, "increment_attempt")
-    mocker.patch.object(uf.facebook_state, "is_published", return_value=False)
-    mocker.patch.object(uf.facebook_state, "clear_pending_upload")
     mocker.patch.object(uf.facebook_api, "upload_video", return_value=_POST_ID)
     mocker.patch.object(uf.facebook_logger, "log_upload_started")
     mocker.patch.object(uf.facebook_logger, "log_upload_published")
@@ -98,18 +105,25 @@ def test_no_pending_job_exits_silently(base):
 
 
 def test_no_pending_job_does_not_modify_state(base):
-    """When there is no pending job, mark_uploading and mark_published are not called."""
+    """When there is no pending job, claim_pending_upload and mark_published are not called."""
     import scripts.upload_facebook as uf
     main([])
-    uf.facebook_state.mark_uploading.assert_not_called()
+    uf.facebook_state.claim_pending_upload.assert_not_called()
     uf.facebook_state.mark_published.assert_not_called()
 
 
-def test_happy_path_marks_uploading(with_pending):
-    """Happy-path upload calls mark_uploading with the idempotency key."""
+def test_happy_path_calls_claim_pending_upload(with_pending):
+    """Happy-path upload claims the job (atomically, via claim_pending_upload) before ever
+    calling the Facebook API — see the issue #34 follow-up regression tests below for why this
+    must be the ONE atomic gate rather than separate get_pending_upload/mark_uploading calls."""
     import scripts.upload_facebook as uf
     main([])
-    uf.facebook_state.mark_uploading.assert_called_once_with(_IDEM_KEY)
+    uf.facebook_state.claim_pending_upload.assert_called_once_with(
+        _IDEM_KEY,
+        cooldown_seconds=uf._COOLDOWN_SECONDS,
+        max_attempts=uf._MAX_ATTEMPTS,
+        lease_seconds=uf._UPLOAD_LEASE_SECONDS,
+    )
 
 
 def test_happy_path_calls_upload_video(with_pending):
@@ -218,10 +232,15 @@ def test_missing_fb_page_id_exits_with_code_1(monkeypatch):
 
 # ---------------------------------------------------------------------------
 # T014: US3 — Retry and failure-recovery paths
+#
+# Cooldown/attempt-budget/claiming decisions now live entirely in
+# facebook_state.claim_pending_upload() (covered directly in test_facebook_state.py) — these
+# tests drive claim_pending_upload's mocked return value to verify upload_facebook.py's OWN
+# dispatch on each outcome, rather than simulating cooldown via the pending record's fields.
 # ---------------------------------------------------------------------------
 
-def test_upload_error_first_attempt_increments_count(base, tmp_path):
-    """FacebookUploadError on attempt 1 increments attempt_count to 1."""
+def test_upload_error_logs_attempt_failed(base, tmp_path):
+    """A FacebookUploadError (claim succeeded, below the attempt budget) logs the failed attempt."""
     import scripts.upload_facebook as uf
     from tools.facebook_api import FacebookUploadError
     video = tmp_path / "video.mp4"
@@ -232,106 +251,154 @@ def test_upload_error_first_attempt_increments_count(base, tmp_path):
 
     main([])
 
-    uf.facebook_state.increment_attempt.assert_called_once_with(_IDEM_KEY)
-
-
-def test_upload_error_first_attempt_sets_last_attempt_at(base, tmp_path):
-    """FacebookUploadError on attempt 1 logs the failure attempt."""
-    import scripts.upload_facebook as uf
-    from tools.facebook_api import FacebookUploadError
-    video = tmp_path / "video.mp4"
-    video.write_bytes(b"\x00" * 64)
-    record = dict(_PENDING_RECORD, video_local_path=str(video))
-    uf.facebook_state.get_pending_upload.return_value = record
-    uf.facebook_api.upload_video.side_effect = FacebookUploadError("timeout")
-
-    main([])
-
     uf.facebook_logger.log_upload_attempt_failed.assert_called_once()
 
 
-def test_upload_error_first_attempt_does_not_send_alert(base, tmp_path):
-    """After the 1st failure, no Telegram alert is sent (more retries remain)."""
+def test_upload_error_below_max_releases_claim_and_does_not_send_alert(base, tmp_path):
+    """A FacebookUploadError with retries remaining (attempt_number < _MAX_ATTEMPTS) releases the
+    claim (so the next attempt is cooldown-gated, not lease-gated — see release_claim's
+    docstring) and does not send a Telegram alert or mark the job failed."""
     import scripts.upload_facebook as uf
     from tools.facebook_api import FacebookUploadError
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
-    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    record = dict(_PENDING_RECORD, video_local_path=str(video), attempt_count=0)
     uf.facebook_state.get_pending_upload.return_value = record
     uf.facebook_api.upload_video.side_effect = FacebookUploadError("timeout")
 
     main([])
 
+    uf.facebook_state.release_claim.assert_called_once_with(_IDEM_KEY)
+    uf.facebook_state.mark_failed.assert_not_called()
     uf.telegram_api.send_message.assert_not_called()
 
 
-def test_cooldown_not_elapsed_exits_without_uploading(base, tmp_path):
-    """If last_attempt_at is within the last 60s, upload_video is not called."""
+def test_claim_cooldown_does_not_call_upload(base, tmp_path):
+    """When claim_pending_upload() declines with 'cooldown', upload_video is never called."""
     import scripts.upload_facebook as uf
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
-    recent = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
-    record = dict(_PENDING_RECORD,
-                  video_local_path=str(video),
-                  attempt_count=1,
-                  last_attempt_at=recent)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
     uf.facebook_state.get_pending_upload.return_value = record
+    uf.facebook_state.claim_pending_upload.return_value = "cooldown"
 
     main([])
 
     uf.facebook_api.upload_video.assert_not_called()
-    uf.facebook_state.increment_attempt.assert_not_called()
+    uf.facebook_state.mark_published.assert_not_called()
+    uf.facebook_state.mark_failed.assert_not_called()
 
 
-def test_cooldown_elapsed_proceeds_to_upload(base, tmp_path):
-    """If last_attempt_at is older than 60s, the upload is attempted."""
+def test_claim_mismatch_does_not_call_upload(base, tmp_path):
+    """When claim_pending_upload() declines with 'mismatch' (the job changed since main()'s
+    snapshot), upload_video is never called."""
     import scripts.upload_facebook as uf
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
-    old = (datetime.now(timezone.utc) - timedelta(seconds=90)).isoformat()
-    record = dict(_PENDING_RECORD,
-                  video_local_path=str(video),
-                  attempt_count=1,
-                  last_attempt_at=old)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
     uf.facebook_state.get_pending_upload.return_value = record
+    uf.facebook_state.claim_pending_upload.return_value = "mismatch"
 
     main([])
 
-    uf.facebook_api.upload_video.assert_called_once()
+    uf.facebook_api.upload_video.assert_not_called()
+
+
+def test_claim_in_flight_does_not_call_upload(base, tmp_path):
+    """When claim_pending_upload() declines with 'in_flight' (another invocation already
+    claimed it — the actual issue #34 check/use race fix), upload_video is never called."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    uf.facebook_state.get_pending_upload.return_value = record
+    uf.facebook_state.claim_pending_upload.return_value = "in_flight"
+
+    main([])
+
+    uf.facebook_api.upload_video.assert_not_called()
+
+
+def test_claim_stale_published_does_not_call_upload_or_mark_failed(base, tmp_path):
+    """When claim_pending_upload() declines with 'stale_published' (already self-healed
+    internally), upload_video is never called and mark_failed is never called either — the
+    exact protection against silently stomping a real, live fb_post_id (issue #34)."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    uf.facebook_state.get_pending_upload.return_value = record
+    uf.facebook_state.claim_pending_upload.return_value = "stale_published"
+
+    main([])
+
+    uf.facebook_api.upload_video.assert_not_called()
+    uf.facebook_state.mark_failed.assert_not_called()
+
+
+def test_claim_stale_failed_does_not_call_upload(base, tmp_path):
+    """When claim_pending_upload() declines with 'stale_failed' (already self-healed
+    internally), upload_video is never called."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    uf.facebook_state.get_pending_upload.return_value = record
+    uf.facebook_state.claim_pending_upload.return_value = "stale_failed"
+
+    main([])
+
+    uf.facebook_api.upload_video.assert_not_called()
+
+
+def test_claim_exhausted_alerts_without_calling_upload_or_mark_failed(base, tmp_path):
+    """When claim_pending_upload() declines with 'exhausted' (attempt_count already at the cap
+    from a prior tick — cleared internally by the claim itself), upload_facebook.py still logs
+    and alerts, but never calls upload_video, and never calls mark_failed again (already
+    cleared — calling it again would be a stale-caller/compare-and-update no-op regardless, but
+    there's no reason to call it at all)."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    uf.facebook_state.get_pending_upload.return_value = record
+    uf.facebook_state.claim_pending_upload.return_value = "exhausted"
+
+    main([])
+
+    uf.facebook_api.upload_video.assert_not_called()
+    uf.facebook_state.mark_failed.assert_not_called()
+    uf.facebook_logger.log_upload_exhausted.assert_called_once_with(_PROJECT)
+    uf.telegram_api.send_message.assert_called_once()
+    text = uf.telegram_api.send_message.call_args.args[1]
+    assert "⚠️" in text
+    assert _PROJECT in text
 
 
 def test_third_failure_marks_failed(base, tmp_path):
-    """After 3 failed attempts, status transitions to failed."""
+    """A FacebookUploadError on the attempt that reaches _MAX_ATTEMPTS (claim succeeded — this
+    IS attempt 3) marks the job failed."""
     import scripts.upload_facebook as uf
     from tools.facebook_api import FacebookUploadError
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
-    old = (datetime.now(timezone.utc) - timedelta(seconds=90)).isoformat()
-    record = dict(_PENDING_RECORD,
-                  video_local_path=str(video),
-                  attempt_count=2,
-                  last_attempt_at=old)
+    record = dict(_PENDING_RECORD, video_local_path=str(video), attempt_count=2)
     uf.facebook_state.get_pending_upload.return_value = record
     uf.facebook_api.upload_video.side_effect = FacebookUploadError("server error")
-    # increment_attempt increments the count in the real impl; mock needs to simulate count=3
-    uf.facebook_state.get_pending_upload.return_value = dict(record)
 
     main([])
 
     uf.facebook_state.mark_failed.assert_called_once_with(_IDEM_KEY)
+    uf.facebook_state.release_claim.assert_not_called()
 
 
 def test_third_failure_logs_exhausted(base, tmp_path):
-    """After 3 failed attempts, log_upload_exhausted is called."""
+    """After the 3rd failed attempt, log_upload_exhausted is called."""
     import scripts.upload_facebook as uf
     from tools.facebook_api import FacebookUploadError
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
-    old = (datetime.now(timezone.utc) - timedelta(seconds=90)).isoformat()
-    record = dict(_PENDING_RECORD,
-                  video_local_path=str(video),
-                  attempt_count=2,
-                  last_attempt_at=old)
+    record = dict(_PENDING_RECORD, video_local_path=str(video), attempt_count=2)
     uf.facebook_state.get_pending_upload.return_value = record
     uf.facebook_api.upload_video.side_effect = FacebookUploadError("server error")
 
@@ -341,16 +408,12 @@ def test_third_failure_logs_exhausted(base, tmp_path):
 
 
 def test_third_failure_sends_telegram_alert(base, tmp_path):
-    """After 3 failed attempts, a Telegram alert is sent to the admin."""
+    """After the 3rd failed attempt, a Telegram alert is sent to the admin."""
     import scripts.upload_facebook as uf
     from tools.facebook_api import FacebookUploadError
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
-    old = (datetime.now(timezone.utc) - timedelta(seconds=90)).isoformat()
-    record = dict(_PENDING_RECORD,
-                  video_local_path=str(video),
-                  attempt_count=2,
-                  last_attempt_at=old)
+    record = dict(_PENDING_RECORD, video_local_path=str(video), attempt_count=2)
     uf.facebook_state.get_pending_upload.return_value = record
     uf.facebook_api.upload_video.side_effect = FacebookUploadError("server error")
 
@@ -363,13 +426,10 @@ def test_third_failure_sends_telegram_alert(base, tmp_path):
 
 
 def test_token_error_marks_failed_immediately(base, tmp_path):
-    """FacebookTokenError immediately marks status=failed after just this one attempt — it does
-    not wait for the retry budget (_MAX_ATTEMPTS) to exhaust, unlike FacebookUploadError.
-
-    increment_attempt IS still called (persisted before the API call, alongside every attempt —
-    see _process_upload's crash-safety comment) but it has no bearing on when mark_failed fires
-    here: that's unconditional on FacebookTokenError, not attempt-count-gated.
-    """
+    """FacebookTokenError immediately marks the job failed after just this one attempt — it does
+    not wait for the retry budget (_MAX_ATTEMPTS) to exhaust, unlike FacebookUploadError, and
+    does not release the claim for a future retry either (mark_failed is unconditional here, not
+    attempt-count-gated)."""
     import scripts.upload_facebook as uf
     from tools.facebook_api import FacebookTokenError
     video = tmp_path / "video.mp4"
@@ -381,6 +441,7 @@ def test_token_error_marks_failed_immediately(base, tmp_path):
     main([])
 
     uf.facebook_state.mark_failed.assert_called_once_with(_IDEM_KEY)
+    uf.facebook_state.release_claim.assert_not_called()
 
 
 def test_token_error_logs_token_expired(base, tmp_path):
@@ -472,10 +533,16 @@ def test_reprocessing_after_publish_does_not_call_upload_video(real_state, tmp_p
     assert real_state.get_pending_upload() is None
 
 
-def test_reprocessing_after_publish_does_not_mark_failed_again(real_state, tmp_path):
+def test_reprocessing_after_publish_does_not_mark_failed_again(real_state, tmp_path, mocker):
     """A second tick against a resolved job must not call mark_failed either — the live incident
-    was this exact call stomping status to 'failed' while a real, live fb_post_id stayed attached."""
+    was this exact call stomping status to 'failed' while a real, live fb_post_id stayed attached.
+
+    Spies on facebook_state.mark_failed (real implementation still runs) rather than only
+    asserting on the resulting persisted state, so this actually proves the call itself never
+    happens on the second tick — not just that its effects didn't happen to show up.
+    """
     import scripts.upload_facebook as uf
+    mark_failed_spy = mocker.spy(real_state, "mark_failed")
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
     record = dict(_PENDING_RECORD, video_local_path=str(video))
@@ -484,9 +551,11 @@ def test_reprocessing_after_publish_does_not_mark_failed_again(real_state, tmp_p
     main([])
     idem_key = record["idempotency_key"]
     assert real_state.is_published(idem_key) is True
+    mark_failed_spy.assert_not_called()
 
     main([])  # second tick must not touch state at all
 
+    mark_failed_spy.assert_not_called()
     data_after_first = json.loads(real_state.STATE_FILE.read_text())
     assert data_after_first["pending_facebook_upload"] is None
     assert idem_key in data_after_first["published_idempotency_keys"]
@@ -516,10 +585,10 @@ def test_terminal_failure_does_not_retry_forever(real_state, tmp_path, monkeypat
 
 
 def test_stale_published_record_is_cleared_without_reprocessing(real_state, tmp_path):
-    """Defense in depth (main()'s explicit is_published check): even if pending_facebook_upload
-    is somehow non-null for a key already in published_idempotency_keys — e.g. a state file
-    written before this fix — main() must clear it and must never call upload_video, and must
-    never overwrite the real fb_post_id via mark_failed."""
+    """Defense in depth (claim_pending_upload()'s stale_published check): even if
+    pending_facebook_upload is somehow non-null for a key already in published_idempotency_keys
+    — e.g. a state file written before this fix — the claim must clear it and never call
+    upload_video, and must never overwrite the real fb_post_id via mark_failed."""
     import scripts.upload_facebook as uf
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
@@ -567,11 +636,14 @@ def test_crash_during_upload_leaves_attempt_persisted_before_the_call(real_state
 
 def test_crash_mid_upload_is_eventually_bounded_by_max_attempts(real_state, tmp_path, monkeypatch):
     """A job stuck 'crashing' every tick (attempt_count advances but the process never reaches
-    the FacebookUploadError handler at all) must still stop retrying once _MAX_ATTEMPTS is
-    reached — checked proactively before calling the API again, so the bound holds regardless of
-    how prior attempts failed (crash vs. a caught API error)."""
+    the FacebookUploadError handler at all — so release_claim() never runs, leaving status
+    stuck at 'uploading') must still stop retrying once _MAX_ATTEMPTS is reached. Each crashed
+    tick leaves the claim looking 'in_flight' until _UPLOAD_LEASE_SECONDS elapses (patched to 0
+    here so the test doesn't sleep) — that's the lease-expiry path that lets an abandoned claim
+    become reclaimable again, subject to the same attempt-budget check as any other retry."""
     import scripts.upload_facebook as uf
     monkeypatch.setattr(uf, "_COOLDOWN_SECONDS", 0)
+    monkeypatch.setattr(uf, "_UPLOAD_LEASE_SECONDS", 0)
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
     record = dict(_PENDING_RECORD, video_local_path=str(video))
@@ -610,3 +682,49 @@ def test_stale_terminal_failed_record_is_cleared_without_reprocessing(real_state
 
     uf.facebook_api.upload_video.assert_not_called()
     assert real_state.get_pending_upload() is None
+
+
+def test_overlapping_main_invocations_only_one_calls_upload_video(real_state, tmp_path):
+    """The exact check/use race a cross-review flagged against the first version of this fix:
+    two overlapping cron invocations of upload_facebook.py (e.g. a slow video upload still
+    running when the next minute's tick starts) must not both call facebook_api.upload_video()
+    for the same job — a real duplicate Facebook post.
+
+    Reproduced end-to-end with two real threads racing against the real, fcntl-locked
+    facebook_state: thread 1 is held INSIDE upload_video() (simulating a slow upload) while
+    thread 2 runs main() to completion. Thread 2 must be declined (claim_pending_upload()
+    returns 'in_flight') without ever calling upload_video() itself.
+    """
+    import threading
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    real_state.set_pending_upload(record)
+
+    call_started = threading.Event()
+    release_call = threading.Event()
+
+    def slow_upload_video(*args, **kwargs):
+        call_started.set()
+        assert release_call.wait(timeout=5), "test deadlocked waiting to release upload_video"
+        return _POST_ID
+
+    uf.facebook_api.upload_video.side_effect = slow_upload_video
+
+    thread1 = threading.Thread(target=main, args=([],))
+    thread1.start()
+    assert call_started.wait(timeout=5), "thread1 never entered upload_video"
+
+    thread2 = threading.Thread(target=main, args=([],))
+    thread2.start()
+    thread2.join(timeout=5)
+    assert not thread2.is_alive(), "thread2 (should have been declined) is still running"
+
+    release_call.set()
+    thread1.join(timeout=5)
+    assert not thread1.is_alive(), "thread1 never finished"
+
+    assert uf.facebook_api.upload_video.call_count == 1
+    assert real_state.get_pending_upload() is None  # thread1 published successfully
+    assert real_state.is_published(_IDEM_KEY) is True

--- a/platform/photo-agent/tests/test_upload_facebook.py
+++ b/platform/photo-agent/tests/test_upload_facebook.py
@@ -67,6 +67,9 @@ def base(mocker, env):
     each outcome.
     """
     import scripts.upload_facebook as uf
+    mock_lock = mocker.MagicMock()
+    mocker.patch.object(uf, "_try_acquire_upload_lock", return_value=mock_lock)
+    mocker.patch.object(uf.fcntl, "flock")
     mocker.patch.object(uf.facebook_state, "get_pending_upload", return_value=None)
     mocker.patch.object(uf.facebook_state, "claim_pending_upload", return_value="claimed")
     mocker.patch.object(uf.facebook_state, "release_claim")
@@ -228,6 +231,24 @@ def test_missing_fb_page_id_exits_with_code_1(monkeypatch):
     with pytest.raises(SystemExit) as exc_info:
         main([])
     assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Cron re-entrancy lock (issue #34 follow-up) — mirrors check_approval.py's
+# test_cron_lock_contention_exits_silently
+# ---------------------------------------------------------------------------
+
+def test_lock_contention_exits_silently_without_touching_state(base):
+    """If upload_facebook.lock is held by another instance, main() exits without ever reading
+    or touching facebook_state at all — not just without calling the Facebook API twice."""
+    import scripts.upload_facebook as uf
+    uf._try_acquire_upload_lock.return_value = None
+
+    main([])
+
+    uf.facebook_state.get_pending_upload.assert_not_called()
+    uf.facebook_state.claim_pending_upload.assert_not_called()
+    uf.facebook_api.upload_video.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -495,12 +516,17 @@ def real_state(tmp_path, monkeypatch, env, mocker):
     """Redirect tools.facebook_state's on-disk file to an isolated tmp path and mock only
     the external side effects (Facebook API, Telegram, structured logging) — facebook_state
     itself stays real so these tests exercise its actual persisted state transitions.
+
+    FIELDKIT_DATA_DIR is also redirected here (not just fb_state.DATA_DIR/STATE_FILE), since
+    upload_facebook.py's real _try_acquire_upload_lock() reads it directly to place
+    upload_facebook.lock — these tests use the real lock too, not a mocked one.
     """
     import scripts.upload_facebook as uf
     data_dir = tmp_path / "photo-agent"
     data_dir.mkdir()
     monkeypatch.setattr(fb_state, "DATA_DIR", data_dir)
     monkeypatch.setattr(fb_state, "STATE_FILE", data_dir / "facebook_state.json")
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("VIDEO_TMP_DIR", str(tmp_path))
     mocker.patch.object(uf.facebook_api, "upload_video", return_value=_POST_ID)
     mocker.patch.object(uf.facebook_logger, "log_upload_started")
@@ -684,23 +710,29 @@ def test_stale_terminal_failed_record_is_cleared_without_reprocessing(real_state
     assert real_state.get_pending_upload() is None
 
 
-def test_overlapping_main_invocations_only_one_calls_upload_video(real_state, tmp_path):
-    """The exact check/use race a cross-review flagged against the first version of this fix:
-    two overlapping cron invocations of upload_facebook.py (e.g. a slow video upload still
-    running when the next minute's tick starts) must not both call facebook_api.upload_video()
-    for the same job — a real duplicate Facebook post.
+def test_overlapping_main_invocations_only_one_calls_upload_video(real_state, tmp_path, mocker):
+    """The exact check/use race a cross-review flagged: two overlapping cron invocations of
+    upload_facebook.py (e.g. a slow video upload still running when the next minute's tick
+    starts) must not both call facebook_api.upload_video() for the same job — a real duplicate
+    Facebook post.
 
-    Reproduced end-to-end with two real threads racing against the real, fcntl-locked
-    facebook_state: thread 1 is held INSIDE upload_video() (simulating a slow upload) while
-    thread 2 runs main() to completion. Thread 2 must be declined (claim_pending_upload()
-    returns 'in_flight') without ever calling upload_video() itself.
+    Reproduced end-to-end with two real threads: thread 1 is held INSIDE upload_video()
+    (simulating a slow upload) while thread 2 runs main() to completion. thread 2 must be
+    declined by the upload_facebook.lock re-entrancy lock BEFORE it ever reads
+    facebook_state at all — a lease-timeout-based reclaim alone (see
+    facebook_state.claim_pending_upload) cannot tell a merely-slow-but-live holder from a
+    crashed one, so the OS-level flock (not the state-level claim) is what must block thread 2
+    here. get_pending_upload is spied (real implementation still runs) to prove thread 2 never
+    reaches it, not just that it never called upload_video.
     """
     import threading
     import scripts.upload_facebook as uf
+    get_pending_spy = mocker.spy(real_state, "get_pending_upload")
     video = tmp_path / "video.mp4"
     video.write_bytes(b"\x00" * 64)
     record = dict(_PENDING_RECORD, video_local_path=str(video))
     real_state.set_pending_upload(record)
+    get_pending_spy.reset_mock()  # ignore the set_pending_upload-adjacent setup above
 
     call_started = threading.Event()
     release_call = threading.Event()
@@ -720,6 +752,11 @@ def test_overlapping_main_invocations_only_one_calls_upload_video(real_state, tm
     thread2.start()
     thread2.join(timeout=5)
     assert not thread2.is_alive(), "thread2 (should have been declined) is still running"
+
+    # thread2 must have been blocked by the OS lock, not by reaching claim_pending_upload and
+    # losing a state-level race — only thread1's own call should be recorded here (thread2 must
+    # never have read facebook_state at all).
+    assert get_pending_spy.call_count == 1, "thread2 read facebook_state before being declined"
 
     release_call.set()
     thread1.join(timeout=5)

--- a/platform/photo-agent/tests/test_upload_facebook.py
+++ b/platform/photo-agent/tests/test_upload_facebook.py
@@ -8,14 +8,22 @@ US3 (T014): transient retry, cooldown, exhaustion, and token-expiry failure path
 
 All external calls (facebook_state, facebook_api, facebook_logger, telegram_api)
 are mocked. No real network or file-system access.
+
+Issue #34 (pending_facebook_upload reprocessing loop) regression tests below use
+the REAL tools.facebook_state read-modify-write state machine, redirected to an
+isolated tmp file via the `real_state` fixture — a fully-mocked facebook_state
+can't reproduce a bug that lives in how state is persisted between cron ticks.
+Only facebook_api/facebook_logger/telegram_api stay mocked there.
 """
 
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
 
+import tools.facebook_state as fb_state
 from scripts.upload_facebook import main
 
 _PROJECT = "test_project"
@@ -55,6 +63,8 @@ def base(mocker, env):
     mocker.patch.object(uf.facebook_state, "mark_published")
     mocker.patch.object(uf.facebook_state, "mark_failed")
     mocker.patch.object(uf.facebook_state, "increment_attempt")
+    mocker.patch.object(uf.facebook_state, "is_published", return_value=False)
+    mocker.patch.object(uf.facebook_state, "clear_pending_upload")
     mocker.patch.object(uf.facebook_api, "upload_video", return_value=_POST_ID)
     mocker.patch.object(uf.facebook_logger, "log_upload_started")
     mocker.patch.object(uf.facebook_logger, "log_upload_published")
@@ -353,7 +363,13 @@ def test_third_failure_sends_telegram_alert(base, tmp_path):
 
 
 def test_token_error_marks_failed_immediately(base, tmp_path):
-    """FacebookTokenError immediately marks status=failed without incrementing attempt_count."""
+    """FacebookTokenError immediately marks status=failed after just this one attempt — it does
+    not wait for the retry budget (_MAX_ATTEMPTS) to exhaust, unlike FacebookUploadError.
+
+    increment_attempt IS still called (persisted before the API call, alongside every attempt —
+    see _process_upload's crash-safety comment) but it has no bearing on when mark_failed fires
+    here: that's unconditional on FacebookTokenError, not attempt-count-gated.
+    """
     import scripts.upload_facebook as uf
     from tools.facebook_api import FacebookTokenError
     video = tmp_path / "video.mp4"
@@ -365,7 +381,6 @@ def test_token_error_marks_failed_immediately(base, tmp_path):
     main([])
 
     uf.facebook_state.mark_failed.assert_called_once_with(_IDEM_KEY)
-    uf.facebook_state.increment_attempt.assert_not_called()
 
 
 def test_token_error_logs_token_expired(base, tmp_path):
@@ -399,3 +414,199 @@ def test_token_error_sends_telegram_alert(base, tmp_path):
     text = uf.telegram_api.send_message.call_args.args[1]
     assert "⚠️" in text
     assert "token" in text.lower() or "reconnect" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Issue #34 regression: pending_facebook_upload reprocessing loop
+#
+# main() used to check only `record is None` before reprocessing — never
+# published_idempotency_keys or status. Combined with mark_published/mark_failed
+# never clearing pending_facebook_upload, every cron tick after a resolved job
+# reprocessed the SAME job forever. In the live incident the video file was
+# already gone (deleted by the success-path cleanup), so it just spammed
+# "video file missing" + mark_failed — which stomped status to "failed" while
+# leaving the real, live fb_post_id attached. Had the file still existed, this
+# would have re-called facebook_api.upload_video and posted a REAL duplicate.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def real_state(tmp_path, monkeypatch, env, mocker):
+    """Redirect tools.facebook_state's on-disk file to an isolated tmp path and mock only
+    the external side effects (Facebook API, Telegram, structured logging) — facebook_state
+    itself stays real so these tests exercise its actual persisted state transitions.
+    """
+    import scripts.upload_facebook as uf
+    data_dir = tmp_path / "photo-agent"
+    data_dir.mkdir()
+    monkeypatch.setattr(fb_state, "DATA_DIR", data_dir)
+    monkeypatch.setattr(fb_state, "STATE_FILE", data_dir / "facebook_state.json")
+    monkeypatch.setenv("VIDEO_TMP_DIR", str(tmp_path))
+    mocker.patch.object(uf.facebook_api, "upload_video", return_value=_POST_ID)
+    mocker.patch.object(uf.facebook_logger, "log_upload_started")
+    mocker.patch.object(uf.facebook_logger, "log_upload_published")
+    mocker.patch.object(uf.facebook_logger, "log_upload_attempt_failed")
+    mocker.patch.object(uf.facebook_logger, "log_upload_exhausted")
+    mocker.patch.object(uf.facebook_logger, "log_token_expired")
+    mocker.patch.object(uf.telegram_api, "send_message")
+    return fb_state
+
+
+def test_reprocessing_after_publish_does_not_call_upload_video(real_state, tmp_path):
+    """The exact issue #34 incident, reproduced end-to-end: a second cron tick against state
+    left over from a successful publish must not call upload_video again. This is the actual
+    line of defense against a real duplicate Facebook post."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    real_state.set_pending_upload(record)
+
+    main([])  # first tick: succeeds, deletes the local file, must clear the pending job
+    assert real_state.get_pending_upload() is None
+    assert not video.exists()
+
+    uf.facebook_api.upload_video.reset_mock()
+    main([])  # second tick: nothing left to reprocess
+
+    uf.facebook_api.upload_video.assert_not_called()
+    assert real_state.get_pending_upload() is None
+
+
+def test_reprocessing_after_publish_does_not_mark_failed_again(real_state, tmp_path):
+    """A second tick against a resolved job must not call mark_failed either — the live incident
+    was this exact call stomping status to 'failed' while a real, live fb_post_id stayed attached."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    real_state.set_pending_upload(record)
+
+    main([])
+    idem_key = record["idempotency_key"]
+    assert real_state.is_published(idem_key) is True
+
+    main([])  # second tick must not touch state at all
+
+    data_after_first = json.loads(real_state.STATE_FILE.read_text())
+    assert data_after_first["pending_facebook_upload"] is None
+    assert idem_key in data_after_first["published_idempotency_keys"]
+
+
+def test_terminal_failure_does_not_retry_forever(real_state, tmp_path, monkeypatch):
+    """Once attempt_count reaches _MAX_ATTEMPTS and the job is marked failed, further cron ticks
+    must not keep calling upload_video with no backoff."""
+    import scripts.upload_facebook as uf
+    from tools.facebook_api import FacebookUploadError
+    monkeypatch.setattr(uf, "_COOLDOWN_SECONDS", 0)
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    real_state.set_pending_upload(record)
+    uf.facebook_api.upload_video.side_effect = FacebookUploadError("server error")
+
+    for _ in range(uf._MAX_ATTEMPTS):
+        main([])
+
+    assert uf.facebook_api.upload_video.call_count == uf._MAX_ATTEMPTS
+    assert real_state.get_pending_upload() is None  # terminal: cleared, not left dangling
+
+    uf.facebook_api.upload_video.reset_mock()
+    main([])  # a 4th tick after exhaustion must not retry
+    uf.facebook_api.upload_video.assert_not_called()
+
+
+def test_stale_published_record_is_cleared_without_reprocessing(real_state, tmp_path):
+    """Defense in depth (main()'s explicit is_published check): even if pending_facebook_upload
+    is somehow non-null for a key already in published_idempotency_keys — e.g. a state file
+    written before this fix — main() must clear it and must never call upload_video, and must
+    never overwrite the real fb_post_id via mark_failed."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    stale_record = dict(
+        _PENDING_RECORD,
+        video_local_path=str(video),
+        status="published",
+        fb_post_id=_POST_ID,
+    )
+    real_state.STATE_FILE.write_text(json.dumps({
+        "pending_facebook_upload": stale_record,
+        "published_idempotency_keys": [_IDEM_KEY],
+    }))
+
+    main([])
+
+    uf.facebook_api.upload_video.assert_not_called()
+    data = json.loads(real_state.STATE_FILE.read_text())
+    assert data["pending_facebook_upload"] is None
+    assert _IDEM_KEY in data["published_idempotency_keys"]
+
+
+def test_crash_during_upload_leaves_attempt_persisted_before_the_call(real_state, tmp_path):
+    """A process that dies inside facebook_api.upload_video() (simulated here as an unhandled
+    exception propagating out of main()) must still have already persisted attempt_count/
+    last_attempt_at — they're written BEFORE the call, not only on a caught failure. Without
+    this, a crashed-but-possibly-succeeded attempt would be retried immediately (no cooldown)
+    and forever (attempt_count frozen), which is the same unbounded-reprocessing shape as the
+    original issue #34 bug, just triggered by a crash instead of a successful publish."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    real_state.set_pending_upload(record)
+    uf.facebook_api.upload_video.side_effect = RuntimeError("simulated process crash mid-upload")
+
+    with pytest.raises(RuntimeError):
+        main([])
+
+    pending = real_state.get_pending_upload()
+    assert pending is not None
+    assert pending["attempt_count"] == 1
+    assert pending["last_attempt_at"] is not None
+
+
+def test_crash_mid_upload_is_eventually_bounded_by_max_attempts(real_state, tmp_path, monkeypatch):
+    """A job stuck 'crashing' every tick (attempt_count advances but the process never reaches
+    the FacebookUploadError handler at all) must still stop retrying once _MAX_ATTEMPTS is
+    reached — checked proactively before calling the API again, so the bound holds regardless of
+    how prior attempts failed (crash vs. a caught API error)."""
+    import scripts.upload_facebook as uf
+    monkeypatch.setattr(uf, "_COOLDOWN_SECONDS", 0)
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    record = dict(_PENDING_RECORD, video_local_path=str(video))
+    real_state.set_pending_upload(record)
+    uf.facebook_api.upload_video.side_effect = RuntimeError("simulated process crash mid-upload")
+
+    for _ in range(uf._MAX_ATTEMPTS):
+        with pytest.raises(RuntimeError):
+            main([])
+
+    pending = real_state.get_pending_upload()
+    assert pending is not None
+    assert pending["attempt_count"] == uf._MAX_ATTEMPTS
+
+    uf.facebook_api.upload_video.reset_mock(side_effect=True)
+    uf.facebook_api.upload_video.side_effect = RuntimeError("would crash again if called")
+    main([])  # must be marked failed WITHOUT calling the API again
+
+    uf.facebook_api.upload_video.assert_not_called()
+    assert real_state.get_pending_upload() is None
+
+
+def test_stale_terminal_failed_record_is_cleared_without_reprocessing(real_state, tmp_path):
+    """Defense in depth: a dangling pending record already marked status='failed' (e.g. left over
+    from a state file written before this fix) must be cleared on the next tick, not reprocessed."""
+    import scripts.upload_facebook as uf
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00" * 64)
+    stale_record = dict(_PENDING_RECORD, video_local_path=str(video), status="failed", attempt_count=3)
+    real_state.STATE_FILE.write_text(json.dumps({
+        "pending_facebook_upload": stale_record,
+        "published_idempotency_keys": [],
+    }))
+
+    main([])
+
+    uf.facebook_api.upload_video.assert_not_called()
+    assert real_state.get_pending_upload() is None

--- a/platform/photo-agent/tools/facebook_state.py
+++ b/platform/photo-agent/tools/facebook_state.py
@@ -3,7 +3,13 @@ State manager for the Facebook video upload pipeline.
 
 Manages:
   $FIELDKIT_DATA_DIR/photo-agent/facebook_state.json
-    — pending VideoUploadJob record + published idempotency keys
+    — pending VideoUploadJob record, published idempotency keys, and a capped
+      history of publish outcomes (published_history)
+
+pending_facebook_upload is always cleared (set back to null) once a job
+resolves — via mark_published() or mark_failed(), both terminal. A cron
+entrypoint must never reprocess a job it finds in this file; the resolved
+state lives in published_idempotency_keys / published_history instead.
 
 All read-modify-write operations acquire an exclusive file lock (fcntl.LOCK_EX)
 before reading and release it after writing, mirroring the pattern in state.py.
@@ -29,11 +35,13 @@ STATE_FILE = DATA_DIR / "facebook_state.json"
 __all__ = [
     "get_pending_upload",
     "set_pending_upload",
+    "clear_pending_upload",
     "mark_uploading",
     "mark_published",
     "mark_failed",
     "increment_attempt",
     "is_published",
+    "find_published",
 ]
 
 _REQUIRED_UPLOAD_KEYS = frozenset({
@@ -48,7 +56,15 @@ _REQUIRED_UPLOAD_KEYS = frozenset({
     "fb_post_id",
 })
 
-_DEFAULTS = {"pending_facebook_upload": None, "published_idempotency_keys": []}
+_DEFAULTS = {
+    "pending_facebook_upload": None,
+    "published_idempotency_keys": [],
+    "published_history": [],
+}
+
+# Cap on published_history so facebook_state.json doesn't grow without bound over a client's
+# lifetime. Only the most recent _PUBLISH_HISTORY_LIMIT publishes are kept.
+_PUBLISH_HISTORY_LIMIT = 100
 
 
 def _read(file_obj) -> dict:
@@ -117,6 +133,20 @@ def set_pending_upload(record: dict) -> None:
             fcntl.flock(f, fcntl.LOCK_UN)
 
 
+def clear_pending_upload() -> None:
+    """Clear pending_facebook_upload back to null, leaving published_idempotency_keys intact."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with _open_for_write() as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            data = _read(f)
+            data["pending_facebook_upload"] = None
+            _write(f, data)
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+    logger.info("clear_pending_upload")
+
+
 def _update_pending(idempotency_key: str, updater) -> None:
     """Read, apply updater(record, data), then write — under exclusive lock."""
     DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -141,21 +171,44 @@ def mark_uploading(idempotency_key: str) -> None:
 
 
 def mark_published(idempotency_key: str, post_id: str) -> None:
-    """Set status=published, store post_id, and append the key to published_idempotency_keys."""
+    """Record the publish (published_idempotency_keys, published_history), then clear
+    pending_facebook_upload.
+
+    A published job is terminal: clearing pending here is what stops the cron
+    entrypoint from ever calling get_pending_upload() and finding this job again.
+    published_history preserves project_name/fb_post_id for callers (e.g. the
+    e2e test rig's find_published()) that need to observe the outcome of a
+    specific publish after the pending record is gone — a capped list rather
+    than a single last-one slot, so an unrelated publish landing in between
+    can't hide an earlier one a caller is still polling for.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
     def _update(record, data):
-        record["status"] = "published"
-        record["fb_post_id"] = post_id
         keys = data.setdefault("published_idempotency_keys", [])
         if idempotency_key not in keys:
             keys.append(idempotency_key)
+        history = data.setdefault("published_history", [])
+        history.append({
+            "project_name": record.get("project_name"),
+            "idempotency_key": idempotency_key,
+            "fb_post_id": post_id,
+            "published_at": now,
+        })
+        del history[:-_PUBLISH_HISTORY_LIMIT]
+        data["pending_facebook_upload"] = None
     _update_pending(idempotency_key, _update)
     logger.info("mark_published: key=%s post_id=%s", idempotency_key, post_id)
 
 
 def mark_failed(idempotency_key: str) -> None:
-    """Transition the pending record's status to 'failed'."""
+    """Clear pending_facebook_upload — every call site treats a failure as terminal (no further
+    retries follow it), so clearing here stops the cron entrypoint from reprocessing this job
+    forever with no backoff. Nothing needs the failed record's fields afterward, so status is
+    not written anywhere (the record itself is discarded, not persisted with status='failed').
+    """
     def _update(record, data):
-        record["status"] = "failed"
+        data["pending_facebook_upload"] = None
     _update_pending(idempotency_key, _update)
     logger.error("mark_failed: key=%s", idempotency_key)
 
@@ -169,6 +222,28 @@ def increment_attempt(idempotency_key: str) -> None:
         record["last_attempt_at"] = now
     _update_pending(idempotency_key, _update)
     logger.info("increment_attempt: key=%s", idempotency_key)
+
+
+def find_published(project_name: str) -> dict | None:
+    """Return the most recent published_history entry for project_name ({project_name,
+    idempotency_key, fb_post_id, published_at}), or None if that project has never been
+    published (within the retained history — see _PUBLISH_HISTORY_LIMIT).
+    """
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(STATE_FILE, "r") as f:
+            fcntl.flock(f, fcntl.LOCK_SH)
+            try:
+                data = _read(f)
+                history = data.get("published_history", [])
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+    except FileNotFoundError:
+        return None
+    for entry in reversed(history):
+        if entry.get("project_name") == project_name:
+            return entry
+    return None
 
 
 def is_published(idempotency_key: str) -> bool:

--- a/platform/photo-agent/tools/facebook_state.py
+++ b/platform/photo-agent/tools/facebook_state.py
@@ -11,6 +11,18 @@ resolves — via mark_published() or mark_failed(), both terminal. A cron
 entrypoint must never reprocess a job it finds in this file; the resolved
 state lives in published_idempotency_keys / published_history instead.
 
+claim_pending_upload() is the only concurrency-safe way to start (or resume)
+uploading the pending job: it collapses what would otherwise be a read, a
+staleness check, and a status/attempt-count transition into ONE exclusive-lock
+read-modify-write, so two overlapping invocations of the cron script (e.g. a
+slow upload still running when the next minute's tick starts) can never both
+observe an unclaimed job and both call the Facebook API. Every mutator that
+takes an idempotency_key (mark_published, mark_failed, release_claim,
+clear_pending_upload) only acts if the CURRENT pending record still has that
+key — compare-and-update, not blind overwrite — so a caller reasoning from an
+earlier snapshot can never corrupt or destroy a different, newer job enqueued
+in its place.
+
 All read-modify-write operations acquire an exclusive file lock (fcntl.LOCK_EX)
 before reading and release it after writing, mirroring the pattern in state.py.
 
@@ -21,7 +33,7 @@ import fcntl
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -35,11 +47,11 @@ STATE_FILE = DATA_DIR / "facebook_state.json"
 __all__ = [
     "get_pending_upload",
     "set_pending_upload",
+    "claim_pending_upload",
+    "release_claim",
     "clear_pending_upload",
-    "mark_uploading",
     "mark_published",
     "mark_failed",
-    "increment_attempt",
     "is_published",
     "find_published",
 ]
@@ -133,41 +145,164 @@ def set_pending_upload(record: dict) -> None:
             fcntl.flock(f, fcntl.LOCK_UN)
 
 
-def clear_pending_upload() -> None:
-    """Clear pending_facebook_upload back to null, leaving published_idempotency_keys intact."""
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    with _open_for_write() as f:
-        fcntl.flock(f, fcntl.LOCK_EX)
-        try:
-            data = _read(f)
-            data["pending_facebook_upload"] = None
-            _write(f, data)
-        finally:
-            fcntl.flock(f, fcntl.LOCK_UN)
-    logger.info("clear_pending_upload")
+def _update_pending(idempotency_key: str, updater) -> bool:
+    """Read; if the CURRENT pending record's idempotency_key still matches idempotency_key,
+    apply updater(record, data) and write — all under one exclusive lock. Returns True if the
+    updater ran, False if there was nothing matching to update (no pending record, already
+    resolved/cleared, or replaced by a newer job under a different key).
 
-
-def _update_pending(idempotency_key: str, updater) -> None:
-    """Read, apply updater(record, data), then write — under exclusive lock."""
+    This compare-before-update is what makes mark_published/mark_failed/clear_pending_upload
+    safe to call from a caller holding an earlier snapshot: they can never mutate or destroy a
+    DIFFERENT job that's since taken the pending slot's place.
+    """
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     with _open_for_write() as f:
         fcntl.flock(f, fcntl.LOCK_EX)
         try:
             data = _read(f)
             record = data.get("pending_facebook_upload")
-            if record is not None:
-                updater(record, data)
+            if record is None or record.get("idempotency_key") != idempotency_key:
+                return False
+            updater(record, data)
             _write(f, data)
+            return True
         finally:
             fcntl.flock(f, fcntl.LOCK_UN)
 
 
-def mark_uploading(idempotency_key: str) -> None:
-    """Transition the pending record's status to 'uploading'."""
+def clear_pending_upload(expected_idempotency_key: str) -> bool:
+    """Clear pending_facebook_upload back to null — but only if the CURRENT pending record's
+    idempotency_key still matches expected_idempotency_key (compare-and-clear). Leaves
+    published_idempotency_keys / published_history intact either way.
+
+    Returns True if cleared, False if left untouched: the job the caller expected to clear had
+    already been cleared/resolved, or a newer job (a different idempotency_key) has since taken
+    the pending slot's place and must not be silently destroyed.
+    """
     def _update(record, data):
-        record["status"] = "uploading"
+        data["pending_facebook_upload"] = None
+    cleared = _update_pending(expected_idempotency_key, _update)
+    logger.info("clear_pending_upload: key=%s cleared=%s", expected_idempotency_key, cleared)
+    return cleared
+
+
+def _has_elapsed(iso_timestamp: str | None, seconds: int, now_dt: datetime) -> bool:
+    """Return True if iso_timestamp is None, unparseable, or at least `seconds` old. None/
+    unparseable count as elapsed: a cooldown/lease exists to prevent premature retries, not to
+    wedge a job forever because of a missing or corrupt timestamp.
+    """
+    if iso_timestamp is None:
+        return True
+    try:
+        last_dt = datetime.fromisoformat(iso_timestamp)
+    except ValueError:
+        logger.warning("unparseable timestamp=%r — treating as elapsed", iso_timestamp)
+        return True
+    return now_dt - last_dt >= timedelta(seconds=seconds)
+
+
+def claim_pending_upload(
+    idempotency_key: str, *, cooldown_seconds: int, max_attempts: int, lease_seconds: int
+) -> str:
+    """Atomically validate and claim the pending job for upload, in a single exclusive-lock
+    read-modify-write. This is the ONLY concurrency-safe way to start an upload attempt: reading
+    the pending record, checking it's not already resolved or claimed, and transitioning it to
+    'uploading' each happen under the SAME lock acquisition rather than three separate ones with
+    a caller-visible gap between them — so two overlapping invocations of the cron script can
+    never both observe an unclaimed job and both call the Facebook API.
+
+    idempotency_key must be the key of the record the caller most recently observed pending. If
+    the CURRENT pending record no longer has that key — cleared, resolved, or replaced by a
+    newer enqueue — this declines rather than acting on stale information.
+
+    lease_seconds bounds how long a claim (status=='uploading') is treated as still genuinely
+    in-progress. Past that, it's treated as abandoned — the claiming process crashed or was
+    killed without calling release_claim() or mark_published()/mark_failed() — and becomes
+    reclaimable again, subject to the same cooldown/attempt-budget checks as any other retry.
+    This is a deliberate lease-pattern tradeoff, not a perfect guarantee: pick lease_seconds
+    comfortably longer than any realistic upload duration, or a legitimately slow upload still
+    running past it could be reclaimed and re-attempted by a second invocation while the first
+    is still genuinely in flight — the same duplicate-post risk this function otherwise closes.
+    See upload_facebook.py's _UPLOAD_LEASE_SECONDS for the chosen value and rationale. A KNOWN
+    (caught) failure should call release_claim() immediately rather than wait out the lease —
+    that's what keeps ordinary retries on the short cooldown instead of the long lease.
+
+    Returns one of:
+      "mismatch"        — no pending record, or its idempotency_key has changed since the
+                           caller's last read. Nothing to do.
+      "in_flight"        — status is 'uploading' and the lease hasn't expired: genuinely claimed
+                           by another still-running invocation. Do not retry.
+      "cooldown"         — last_attempt_at is too recent (within cooldown_seconds). Nothing to do.
+      "stale_published"  — idempotency_key is already in published_idempotency_keys; cleared.
+      "stale_failed"     — status was already 'failed'; cleared.
+      "exhausted"        — attempt_count already at max_attempts; cleared (terminal failure).
+      "claimed"          — success: status is now 'uploading', attempt_count/last_attempt_at
+                           already advanced for this attempt. The caller should now attempt the
+                           upload using the OTHER (immutable) fields from its own snapshot —
+                           project_name/video_local_path/page_id/idempotency_key never change
+                           across a record's lifetime.
+    """
+    now_dt = datetime.now(timezone.utc)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with _open_for_write() as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            data = _read(f)
+            record = data.get("pending_facebook_upload")
+            if record is None or record.get("idempotency_key") != idempotency_key:
+                return "mismatch"
+
+            if idempotency_key in data.get("published_idempotency_keys", []):
+                data["pending_facebook_upload"] = None
+                _write(f, data)
+                return "stale_published"
+
+            if record.get("status") == "failed":
+                data["pending_facebook_upload"] = None
+                _write(f, data)
+                return "stale_failed"
+
+            last_attempt_at = record.get("last_attempt_at")
+
+            if record.get("status") == "uploading":
+                if not _has_elapsed(last_attempt_at, lease_seconds, now_dt):
+                    return "in_flight"
+                # Lease expired: treat as an abandoned claim and fall through to the same
+                # cooldown/attempt-budget checks as any other reclaim.
+
+            if not _has_elapsed(last_attempt_at, cooldown_seconds, now_dt):
+                return "cooldown"
+
+            attempt_count = record.get("attempt_count", 0)
+            if attempt_count >= max_attempts:
+                data["pending_facebook_upload"] = None
+                _write(f, data)
+                return "exhausted"
+
+            record["status"] = "uploading"
+            record["attempt_count"] = attempt_count + 1
+            record["last_attempt_at"] = now_dt.isoformat()
+            _write(f, data)
+            return "claimed"
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def release_claim(idempotency_key: str) -> None:
+    """Release a claim after a KNOWN, retryable (non-terminal) failure — resets status back to
+    'pending' so the next claim_pending_upload() call is gated by the short retry cooldown
+    rather than the much longer abandoned-claim lease. Call this whenever an upload attempt
+    fails in a way the caller catches and intends to retry (e.g. FacebookUploadError below
+    _MAX_ATTEMPTS). attempt_count/last_attempt_at — already advanced by the claim — are left as
+    they are; that's what makes the next claim's cooldown/attempt-budget checks correct.
+
+    Compare-and-update (via _update_pending): a no-op if the current pending record's
+    idempotency_key no longer matches.
+    """
+    def _update(record, data):
+        record["status"] = "pending"
     _update_pending(idempotency_key, _update)
-    logger.info("mark_uploading: key=%s", idempotency_key)
+    logger.info("release_claim: key=%s", idempotency_key)
 
 
 def mark_published(idempotency_key: str, post_id: str) -> None:
@@ -213,21 +348,14 @@ def mark_failed(idempotency_key: str) -> None:
     logger.error("mark_failed: key=%s", idempotency_key)
 
 
-def increment_attempt(idempotency_key: str) -> None:
-    """Increment attempt_count by 1 and set last_attempt_at to now (UTC ISO-8601)."""
-    now = datetime.now(timezone.utc).isoformat()
-
-    def _update(record, data):
-        record["attempt_count"] = record.get("attempt_count", 0) + 1
-        record["last_attempt_at"] = now
-    _update_pending(idempotency_key, _update)
-    logger.info("increment_attempt: key=%s", idempotency_key)
-
-
 def find_published(project_name: str) -> dict | None:
     """Return the most recent published_history entry for project_name ({project_name,
     idempotency_key, fb_post_id, published_at}), or None if that project has never been
-    published (within the retained history — see _PUBLISH_HISTORY_LIMIT).
+    published — including if it WAS published but has since aged out of the retained history
+    (only the most recent _PUBLISH_HISTORY_LIMIT publishes are kept; see mark_published()). A
+    caller polling for a specific publish (e.g. the e2e test rig's Stage 5) should only rely on
+    this within a reasonably short window of that publish happening — practically never a
+    concern for a manually-run e2e test, but worth knowing if this is ever reused elsewhere.
     """
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     try:


### PR DESCRIPTION
## Summary

Fixes a confirmed live production bug (real duplicate-Facebook-post risk): `mark_published()` never cleared `pending_facebook_upload` after a successful publish, and `upload_facebook.py::main()` only checked `record is None` before reprocessing — never `published_idempotency_keys` or `status`. Every cron tick after a successful publish reprocessed the same already-published job forever. In the live incident the video file happened to already be deleted by the success-path cleanup, so it just spammed `video file missing` + `mark_failed` (stomping status while leaving the real, live `fb_post_id` attached). Had the file still existed, it would have re-called `facebook_api.upload_video` — a real duplicate Facebook post.

- `mark_published()` / `mark_failed()` (`tools/facebook_state.py`) now both clear `pending_facebook_upload` as part of their atomic locked write, since both represent terminal outcomes.
- `e2e_stage4_await_approval.py` / `e2e_stage5_await_facebook.py` use a new capped `published_history` (+ `find_published(project_name)`) as the source of truth for "did this job publish" — clearing the pending slot broke Stage 5, which used to poll `get_pending_upload()` for `status == "published"` to learn the `fb_post_id`.

### Update: fixed two blocking findings from cross-review

A cross-review (codex) of the first version of this fix found two real, blocking concurrency bugs:

1. **Check/use race** — `get_pending_upload()`, `is_published()`, and `mark_uploading()`/`increment_attempt()` each acquired their own separate lock. Two overlapping cron invocations (e.g. a slow video upload still running past 60s when the next minute's tick starts — plausible for real video files) could both observe an unclaimed job and both call `facebook_api.upload_video()` — a real duplicate post.
2. **Stale-clear race** — the defense-in-depth path read a record snapshot, checked `is_published()` against it, then called `clear_pending_upload()` unconditionally; if a *different, newer* job had since been enqueued, that call would silently destroy it.

Fix: `tools/facebook_state.py` gets a single atomic `claim_pending_upload()` that does the read, staleness check, cooldown check, and status/attempt-count transition all under **one** exclusive-lock read-modify-write — closing finding 1 by construction. Every mutator keyed by `idempotency_key` (`mark_published`, `mark_failed`, `clear_pending_upload`, and new `release_claim`) is now compare-and-update — it only acts if the *current* pending record still has the expected key — closing finding 2, and the same latent bug in `mark_published`/`mark_failed` themselves, not just `clear_pending_upload`. `mark_uploading`/`increment_attempt` are removed (superseded by the atomic claim; keeping them around as still-callable-but-unsafe functions would have been a footgun).

Implementing the atomic claim surfaced a real regression risk against the crash-mid-upload fix from the previous round: an unconditional "`status == 'uploading'` blocks forever" rule would let a transient, *caught* `FacebookUploadError` wedge a job at `in_flight` permanently, and would let a genuinely crashed job (uncaught exception) hang forever with no alert. Fixed with a lease pattern — `claim_pending_upload()` treats a stale `uploading` claim (older than `_UPLOAD_LEASE_SECONDS = 900`, deliberately much longer than any realistic upload) as abandoned and reclaimable, subject to the same attempt budget as any other retry; `release_claim()` resets a job immediately after a known, caught, retryable failure so ordinary retries stay on the short cooldown rather than waiting out the lease.

### Update: fixed a blocking gap in the lease-fencing itself

A third round of cross-review confirmed the two findings above were genuinely fixed, but found a real gap in the lease-reclaim mechanism itself: `claim_pending_upload()` reclaims an `uploading` job once its lease expires, but nothing actually guarantees the original holder's `upload_video()` call has stopped by then. A genuinely *slow* (not crashed) upload running past 900s could be reclaimed and re-attempted by a second invocation while the first is still live — both could post real duplicates. Separately, a late-returning expired holder calling `release_claim()`/`mark_failed()` could stomp a second holder's now-active reclaimed attempt, since nothing distinguished the two.

Fix: reused `check_approval.py`'s existing, already-proven pattern instead of a token/fencing scheme — a non-blocking `fcntl.flock` on a dedicated `upload_facebook.lock` file, held for the *entire* duration of processing a claimed job (before `claim_pending_upload()` through `mark_published`/`mark_failed`/`release_claim`). A second invocation that can't acquire the lock exits immediately, before ever touching `facebook_state` at all — this sidesteps the whole lease-timeout race for any genuinely live process, since `flock` is crash-safe (released automatically by the OS on process death) but never releases for a process that's simply still running slowly. The lease/reclaim logic in `claim_pending_upload()` stays as defense-in-depth (harmless, already tested) but is no longer the primary correctness mechanism — the OS lock is.

## Test plan

- [x] **Lock-contention test** (`test_lock_contention_exits_silently_without_touching_state`, mirrors `check_approval.py`'s own): when `upload_facebook.lock` is held elsewhere, `main()` exits without ever calling `facebook_state.get_pending_upload()` or `claim_pending_upload()` — not just without calling the API.
- [x] **Real two-thread concurrency test** (`test_overlapping_main_invocations_only_one_calls_upload_video`) against the real fcntl-locked lock file and state file, reproducing the exact overlapping-cron-tick scenario end-to-end: thread 1 held inside `upload_video()`, thread 2 runs `main()` to completion. A spy on `get_pending_upload` proves thread 2 is blocked by the OS lock itself (never reads `facebook_state` at all) rather than merely losing a state-level race — only one thread ever calls `upload_video()`.
- [x] **Exact compare-and-clear interleaving from finding 2** (`test_clear_pending_upload_does_not_destroy_a_newer_job`, `test_mark_failed_does_not_destroy_a_newer_job`, `test_release_claim_does_not_destroy_a_newer_job`): job A resolves, job B is enqueued, a stale mutator call for A's key leaves B untouched.
- [x] Full `claim_pending_upload`/`release_claim` coverage in `test_facebook_state.py`: claimed, mismatch, in_flight, cooldown, stale_published, stale_failed, exhausted, lease-expiry reclaim, exhausted-after-lease-expiry, and a real concurrent-threads test proving only one of two simultaneous claims succeeds.
- [x] Regression tests reproducing the original incident end-to-end via a `real_state` fixture in `test_upload_facebook.py` that exercises the *real* `facebook_state` read-modify-write cycle (redirected to an isolated tmp file — see the PR #23 test-isolation incident) rather than a fully-mocked one: `test_reprocessing_after_publish_does_not_call_upload_video`, `test_reprocessing_after_publish_does_not_mark_failed_again` (spies on `mark_failed`, not just resulting state), `test_terminal_failure_does_not_retry_forever`, `test_crash_during_upload_leaves_attempt_persisted_before_the_call`, `test_crash_mid_upload_is_eventually_bounded_by_max_attempts`, `test_stale_published_record_is_cleared_without_reprocessing`, `test_stale_terminal_failed_record_is_cleared_without_reprocessing`.
- [x] `test_run_e2e_test.py` updated for Stage 4/5's `find_published` fallback, including the exact race Stage 4 needed a fix for (job resolves before Stage 4 samples it pending).
- [x] `published_history`'s 100-entry-cap consequence documented on `find_published()`.
- [x] Full photo-agent suite green — run locally, reproducible with:
  ```
  FIELDKIT_DATA_DIR=<isolated-tmp-dir> FIELDKIT_LOG_DIR=<isolated-tmp-dir>/logs CLIENT_NAME=_demo \
    python3 -m pytest tests/ -q
  ```
  → **451 passed, 0 failed** (428 → 450 → 451 across the three review rounds).
- [x] Verified no test writes leak to the real `FIELDKIT_DATA_DIR` (checked the scratch dir is empty after every run — see the PR #23 test-isolation incident this repo already hit once).

Closes #34

