### PR TITLE
Remove stale Mac Mini boilerplate from spec-template Constraints

### DIFF
--- a/.specify/templates/overrides/spec-template.md
+++ b/.specify/templates/overrides/spec-template.md
@@ -104,9 +104,9 @@
 ## Constraints & Assumptions
 
 **Constraints:**
-- Runs on a Mac Mini (on-premise, transferred to client after completion)
+- [Deployment/runtime environment for this feature]
 - Must operate within daily AI budget limit
-- No cloud storage — all data stays on Mac Mini
+- [Data storage/residency requirements]
 - [Feature-specific constraints]
 
 **Assumptions:**

--- a/clients/_template/.specify/constitution.md
+++ b/clients/_template/.specify/constitution.md
@@ -6,7 +6,7 @@ This constitution establishes the governing principles, values, and constraints 
 
 **Last Updated:** [Date]
 **Status:** Draft
-**Deployment Model:** Mac Mini (on-premise, transferred to client after completion)
+**Deployment Model:** [e.g., on-premise hardware, cloud-hosted, hybrid — describe this client's deployment]
 **AI Provider:** [Model provider — Hermes Agent runtime, Anthropic (default) or OpenAI (per-client choice); see the FieldKit framework constitution]
 **Development Approach:** Phased implementation
 
@@ -14,20 +14,17 @@ This constitution establishes the governing principles, values, and constraints 
 
 ## Deployment Architecture
 
-### Mac Mini Model
+### [Deployment Model — e.g., On-Premise Hardware, Cloud-Hosted, Hybrid]
 
-**Hardware Ownership:**
-- FieldKit provides Mac Mini for development and deployment
-- Mac Mini runs 24/7 at developer location during development
-- Upon project completion, Mac Mini transferred to [Client Name]
-- [Client Name] owns hardware and can maintain independently
+**Hosting & Ownership:**
+- [Describe where the system runs and who owns/hosts the infrastructure]
+- [Describe any handoff or ownership transfer at project completion, if applicable]
 
 **Implications:**
-- AI inference now routes to a cloud model provider (Anthropic or OpenAI) via Hermes Agent — no longer self-contained for AI inference specifically; other data remains local
-- All data stored locally on Mac Mini
-- Client has full control and ownership
-- No recurring hosting costs
-- System continues running after FieldKit engagement ends
+- AI inference routes to a cloud model provider (Anthropic or OpenAI) via Hermes Agent
+- [Describe the data storage/residency model — local, cloud, hybrid]
+- [Describe the cost model — recurring hosting costs, one-time hardware cost, etc.]
+- [Describe what happens to the system after the FieldKit engagement ends]
 
 ---
 
@@ -47,7 +44,7 @@ This constitution establishes the governing principles, values, and constraints 
 - [ ] All metadata (GPS, timestamps, camera info) stripped from photos before posting
 - [ ] No [industry-specific identifying info] in published content
 - [ ] Human verification required for all customer-facing content
-- [ ] All customer data stored locally on Mac Mini (not cloud)
+- [ ] [Data storage/residency requirement — e.g., local-only, specific cloud region, no third-party storage]
 - [ ] [Add client-specific requirements]
 
 ---
@@ -112,13 +109,13 @@ This constitution establishes the governing principles, values, and constraints 
 
 ### 5. Data Integrity & Preservation
 
-**Principle:** Business data is valuable and should be preserved. Local storage ensures control.
+**Principle:** Business data is valuable and should be preserved. [Describe this client's approach to data control.]
 
 **Data Storage:**
-- All data stored on Mac Mini
-- No cloud storage (except necessary external services — list them)
+- [Data storage/residency model — e.g., local-only, cloud, hybrid]
+- [Cloud storage policy, if any — list any necessary external services]
 - Backup strategy: [Who is responsible? What is the approach?]
-- Data ownership: [Client name] owns all data on their Mac Mini
+- Data ownership: [Client name] owns all data — [describe where/how it's stored]
 
 **External Services Used:**
 - [ ] Gmail (email)
@@ -147,13 +144,13 @@ This constitution establishes the governing principles, values, and constraints 
 ## Technical Constraints
 
 ### Infrastructure Requirements
-- Mac Mini M-series
+- [Deployment hardware/platform — e.g., on-premise Mac Mini, cloud VM, managed service]
 - Reliable internet connection (always-on)
 - Gmail account for email workflows
-- macOS for deployment
+- [Operating system / platform requirement, if any]
 
 ### Hermes Integration
-- Self-hosted Hermes Agent runtime on Mac Mini; model calls route to the chosen cloud provider (Anthropic or OpenAI)
+- Hermes Agent runtime; model calls route to the chosen cloud provider (Anthropic or OpenAI)
 - Model selection based on task complexity
 - Token usage monitoring for cost tracking
 
@@ -192,13 +189,13 @@ When conflicts arise, resolve in this order:
 
 ---
 
-## Hardware Transfer Plan
+## Transition Plan
 
 **Upon Project Completion:**
 
 1. **System Validation** — all agreed features working, client satisfied
 2. **Knowledge Transfer** — training session, documentation handoff, admin guide
-3. **Physical Transfer** — Mac Mini delivered to client location, connectivity verified
+3. **Handoff** — [describe what's transferred — e.g., physical hardware, cloud account access, credentials — based on this client's deployment model]
 4. **Post-Transfer Support** — 30-day support period included
 5. **Long-Term** — client owns and operates system; source code provided
 
@@ -208,7 +205,7 @@ When conflicts arise, resolve in this order:
 
 By implementing this system, all stakeholders agree to:
 - Respect the privacy principles above
-- Maintain Mac Mini hardware properly
+- [Maintain deployment infrastructure properly, per the deployment model above]
 - Operate within budget constraints
 - Follow approval workflows
 - Prioritize customer satisfaction and business sustainability
@@ -218,5 +215,5 @@ By implementing this system, all stakeholders agree to:
 *Established: [Date]*
 *Authority: [Client Name] Business Owner*
 *Framework: FieldKit*
-*Deployment: Mac Mini (on-premise)*
+*Deployment: [on-premise / cloud-hosted / hybrid — per client]*
 *AI Provider: [Hermes Agent — Anthropic or OpenAI per client]*

--- a/clients/_template/.specify/constitution.md
+++ b/clients/_template/.specify/constitution.md
@@ -59,7 +59,7 @@ This constitution establishes the governing principles, values, and constraints 
 - **Enforcement:** System automatically pauses AI operations when daily limit reached
 
 **Hermes Cost Model:**
-- Self-hosted Hermes Agent supervisor process (one-time hardware cost)
+- [Agent runtime hosting and associated cost model]
 - Per-token API costs to the chosen model provider (Anthropic or OpenAI)
 - External API costs for other services that can't be self-hosted (e.g. computer vision, social APIs)
 


### PR DESCRIPTION
## Summary
- `.specify/templates/overrides/spec-template.md` — replaced the retired-architecture Constraints boilerplate (`Runs on a Mac Mini (on-premise...)` / `No cloud storage — all data stays on Mac Mini`) with neutral `[...]` placeholders, matching the placeholder convention already used elsewhere in the file.
- `clients/_template/.specify/constitution.md` — replaced retired-architecture content stated as current fact (on-premise Mac Mini deployment/ownership, local-only/no-cloud-storage data residency, Mac-specific infrastructure requirements, the "Hardware Transfer Plan", and the Hermes Cost Model's self-hosted/one-time-hardware-cost claim) with architecture-neutral placeholders. Section structure and unrelated content (privacy, budget, approval, testing principles) are unchanged — this is not a full constitution rewrite, just removing claims retired by the cloud pivot.

## Scope note
`.specify/templates/spec-template.md` (non-override base) was also checked per the acceptance criteria — no Mac Mini / stale Constraints boilerplate found there. Not touched.

`Log all errors locally` (Error Handling Philosophy section) was left as-is — it's an operational logging instruction, not a deployment/residency guarantee, so it doesn't fall under the retired-architecture claims this issue targets.

Closes #10

## Test plan
- [x] Diff reviewed on both files — only retired-architecture content touched, no other content changed
- [x] `grep -n "Mac Mini"` on the constitution template confirms the only remaining hit is inside a bracketed example placeholder (`e.g., on-premise Mac Mini, cloud VM, managed service`), not asserted as current fact
- [x] Docs-only change, no functional/code impact — no test suite applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)