### PR TITLE
docs: complete constitution.md Architecture Constraints for Hermes + cloud pivot

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -12,7 +12,7 @@
 
 - ALL metadata (GPS, timestamps, camera info, faces) stripped from media before any output
 - No customer-identifying information (addresses, license plates, names) in published content
-- Customer data storage ownership model is being redefined by the Mac Mini → Cloud pivot (see `platform/.specify/003-hermes-runtime/spec.md`) — the pre-pivot "Mac-Mini-only, never uploaded to external cloud storage" guarantee no longer holds as stated; the replacement model is not yet finalized
+- Customer data storage ownership model is being redefined by the Mac Mini → Cloud pivot (see `platform/.specify/003-hermes-runtime/spec.md`) — the pre-pivot "Mac-Mini-only, never uploaded to external cloud storage" guarantee no longer holds as stated; W3 will define the replacement model
 - Consent must be established before using any customer data or photos
 
 ### Gate 2 — Human-in-the-Loop
@@ -32,7 +32,7 @@
 ### Gate 4 — Client Ownership
 
 - All code and data owned by the client — no proprietary lock-in
-- Hardware/deployment ownership model is being redefined by the Mac Mini → Cloud pivot (see `platform/.specify/003-hermes-runtime/spec.md`) — the replacement for "Mac Mini hardware transferred to client upon project completion" is not yet finalized
+- Hardware/deployment ownership model is being redefined by the Mac Mini → Cloud pivot (see `platform/.specify/003-hermes-runtime/spec.md`) — the replacement for "Mac Mini hardware transferred to client upon project completion" is not yet finalized; W3 will define the replacement ownership/deployment model
 - Full test suite included in client handoff
 - System continues operating after FieldKit engagement ends
 
@@ -60,7 +60,7 @@ When conflicts arise, resolve in this order:
 
 ## Architecture Constraints
 
-- **Runtime:** Hermes Agent (self-hosted supervisor process on Mac Mini)
+- **Runtime:** Hermes Agent (self-hosted on Mac Mini; see dev-infrastructure plan-of-record for the cloud roadmap)
 - **Platform:** macOS (Mac Mini M-series), Python 3.11+
 - **Testing:** pytest + pytest-mock
 - **Model routing:** cloud inference via Anthropic (default) or OpenAI (explicit per-client choice) — the earlier "no cloud AI inference, all LLM work runs locally" constraint no longer holds
@@ -84,4 +84,4 @@ Every feature must produce all of the following before implementation starts:
 
 ---
 
-**Version:** 1.1 | **Ratified:** 2026-05-20 | **Amended:** 2026-08-23 (issue #9 — Architecture Constraints updated for the Hermes runtime and the Mac Mini → Cloud pivot; see `platform/.specify/003-hermes-runtime/spec.md`) | **Framework:** FieldKit
+**Version:** 1.2 | **Ratified:** 2026-05-20 | **Amended:** 2026-08-24 (issue #9 — Architecture Constraints corrected to match full acceptance criteria: Runtime now references the dev-infrastructure plan-of-record for the cloud roadmap, and Gates 1/4 note that W3 will define the replacement ownership/deployment model; see `platform/.specify/003-hermes-runtime/spec.md`) | **Framework:** FieldKit

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -12,7 +12,7 @@
 
 - ALL metadata (GPS, timestamps, camera info, faces) stripped from media before any output
 - No customer-identifying information (addresses, license plates, names) in published content
-- Customer data storage ownership model is being redefined by the Mac Mini → Cloud pivot (see `platform/.specify/003-hermes-runtime/spec.md`) — the pre-pivot "Mac-Mini-only, never uploaded to external cloud storage" guarantee no longer holds as stated; W3 will define the replacement model
+- Customer data storage ownership model is being redefined by the Mac Mini → Cloud pivot (see `platform/.specify/003-hermes-runtime/spec.md`) — the pre-pivot "Mac-Mini-only, never uploaded to external cloud storage" guarantee no longer holds as stated; W3 (the cloud-deployment ownership workstream tracked in the dev-infrastructure plan-of-record) will define the replacement model
 - Consent must be established before using any customer data or photos
 
 ### Gate 2 — Human-in-the-Loop
@@ -61,10 +61,10 @@ When conflicts arise, resolve in this order:
 ## Architecture Constraints
 
 - **Runtime:** Hermes Agent (self-hosted on Mac Mini; see dev-infrastructure plan-of-record for the cloud roadmap)
-- **Platform:** macOS (Mac Mini M-series), Python 3.11+
+- **Platform:** macOS (Mac Mini M-series; interim development home only, not the permanent deployment target — see Runtime above), Python 3.11+
 - **Testing:** pytest + pytest-mock
 - **Model routing:** cloud inference via Anthropic (default) or OpenAI (explicit per-client choice) — the earlier "no cloud AI inference, all LLM work runs locally" constraint no longer holds
-- **No cloud storage** — Google Drive is the exception for client-initiated uploads only
+- **No cloud storage (interim only):** Google Drive remains the exception for client-initiated uploads only; this constraint is being redefined by the Mac Mini → Cloud pivot (see Gate 1) — W3 will define the replacement
 - **Admin interface:** Telegram (commands + callback keyboards)
 
 ---
@@ -84,4 +84,4 @@ Every feature must produce all of the following before implementation starts:
 
 ---
 
-**Version:** 1.2 | **Ratified:** 2026-05-20 | **Amended:** 2026-08-24 (issue #9 — Architecture Constraints corrected to match full acceptance criteria: Runtime now references the dev-infrastructure plan-of-record for the cloud roadmap, and Gates 1/4 note that W3 will define the replacement ownership/deployment model; see `platform/.specify/003-hermes-runtime/spec.md`) | **Framework:** FieldKit
+**Version:** 1.3 | **Ratified:** 2026-05-20 | **Amended:** 2026-08-24 (issue #9 — resolved two contradictions the v1.2 pass left standing: Platform and "No cloud storage" were still stated as unconditional current facts while Gate 1 already admitted the Mac-Mini/no-cloud-storage guarantee no longer holds — both now carry the same interim/W3-pending qualification as Runtime; also expanded "W3" on first use; see `platform/.specify/003-hermes-runtime/spec.md`) | **Framework:** FieldKit


### PR DESCRIPTION
## Summary
- Closes #9. Completes the Architecture Constraints update for the Hermes runtime and Mac Mini → Cloud pivot.
- A prior commit (4f09319, landed while closing #14) pre-applied a paraphrased version of these edits, but didn't match #9's literal acceptance criteria wording. This PR corrects the remaining gaps:
  - **Runtime** line now reads `Hermes Agent (self-hosted on Mac Mini; see dev-infrastructure plan-of-record for the cloud roadmap)`, matching the AC exactly.
  - Gate 1 (`Customer data stored only on the client's Mac Mini...`) and Gate 4 (`Mac Mini hardware transferred to client...`) rewrites now explicitly note that **W3** will define the replacement ownership/deployment model, per the AC.
  - Version/Ratified footer bumped: `1.1` → `1.2`, `Amended` date → 2026-08-24, with a changelog note describing the correction.
- The already-accurate `No cloud AI inference — all LLM work runs locally via OpenClaw` rewrite (Model routing bullet) was left as-is — it already satisfied the AC.
- Docs only, no functional/code changes.

## Test plan
- [x] No doc-lint or test gates exist in this repo for spec-kit files (verified: no markdownlint config, no Makefile/CI target covering `.specify/`).
- [x] Verified markdown is well-formed (balanced headers, structure intact, `python3` sanity check).
- [x] Diffed against `origin/main` to confirm only the intended `.specify/memory/constitution.md` lines changed.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)