### PR TITLE
Fix approval email HTTP 403: widen Drive OAuth scope to include gmail.send

### DIFF
--- a/platform/photo-agent/scripts/setup_drive_auth.py
+++ b/platform/photo-agent/scripts/setup_drive_auth.py
@@ -1,5 +1,5 @@
 """
-setup_drive_auth.py — One-time Google Drive OAuth2 setup.
+setup_drive_auth.py — One-time Google OAuth2 setup for Drive + Gmail-send.
 
 Reads client_id and client_secret from ~/.config/gws/client_secret.json,
 opens a browser-based OAuth2 consent flow, exchanges the auth code for a
@@ -12,6 +12,15 @@ Usage:
 Run this whenever the stored refresh token stops working (HTTP 400/401 from
 drive.py's _get_access_token). It bypasses `gws auth export`, which can export
 stale credentials even after a fresh `gws auth login`.
+
+Scope (issue #35): _SCOPE requests both drive and gmail.send. This credential
+is deliberately shared — check_approval.py's _send_approval_email() reuses
+drive.py's _get_access_token() as its Gmail-send credential rather than
+maintaining a second OAuth2 flow, so the token this script mints must satisfy
+both APIs. Do NOT narrow this back to drive-only; that reintroduces the
+Gmail-send HTTP 403 that issue #35 fixed. If drive-only and gmail-send ever
+need separate credentials, give _send_approval_email its own token source
+instead of shrinking this one.
 """
 
 import json
@@ -26,7 +35,9 @@ _CLIENT_SECRET_FILE = Path("~/.config/gws/client_secret.json").expanduser()
 _USER_CREDENTIALS_FILE = Path("~/.config/gws/user_credentials.json").expanduser()
 _AUTH_URL = "https://accounts.google.com/o/oauth2/auth"
 _TOKEN_URL = "https://oauth2.googleapis.com/token"
-_SCOPE = "https://www.googleapis.com/auth/drive"
+# Space-separated per OAuth2 convention. Shared Drive + Gmail-send credential
+# — see the module docstring's "Scope (issue #35)" note before changing this.
+_SCOPE = "https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/gmail.send"
 _REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
 
 

--- a/platform/photo-agent/tests/test_setup_drive_auth.py
+++ b/platform/photo-agent/tests/test_setup_drive_auth.py
@@ -1,0 +1,73 @@
+"""
+Tests for scripts/setup_drive_auth.py — the one-time OAuth2 setup script.
+
+Covers the _SCOPE constant (issue #35: this credential is deliberately shared
+between Drive and Gmail-send — check_approval.py's _send_approval_email()
+reuses drive.py's _get_access_token() rather than minting a separate Gmail
+token) and main()'s propagation of that scope into the auth URL. Network
+calls, the browser, and stdin are all mocked — no real HTTP or interaction.
+"""
+
+import json
+import urllib.parse
+
+import pytest
+
+from scripts.setup_drive_auth import _SCOPE
+
+
+# ---------------------------------------------------------------------------
+# _SCOPE — issue #35: must request both Drive and Gmail-send
+# ---------------------------------------------------------------------------
+
+def test_scope_includes_drive():
+    """_SCOPE requests the Drive scope needed by tools/drive.py's Drive calls."""
+    assert "https://www.googleapis.com/auth/drive" in _SCOPE.split()
+
+
+def test_scope_includes_gmail_send():
+    """_SCOPE requests gmail.send — check_approval.py's _send_approval_email()
+    reuses this same credential to send mail via the Gmail API."""
+    assert "https://www.googleapis.com/auth/gmail.send" in _SCOPE.split()
+
+
+def test_scope_is_space_separated_per_oauth2_convention():
+    """_SCOPE is a single space-separated string, not a list or comma-joined."""
+    scopes = _SCOPE.split(" ")
+    assert len(scopes) == 2
+    assert "," not in _SCOPE
+
+
+# ---------------------------------------------------------------------------
+# main() — the scope must actually reach the auth URL sent to Google
+# ---------------------------------------------------------------------------
+
+def test_main_auth_url_requests_full_scope(mocker, tmp_path):
+    """main() builds the OAuth2 auth URL with the full drive+gmail.send scope."""
+    import scripts.setup_drive_auth as sda
+
+    client_secret_file = tmp_path / "client_secret.json"
+    client_secret_file.write_text(json.dumps({
+        "installed": {"client_id": "cid", "client_secret": "csecret"}
+    }))
+    creds_file = tmp_path / "user_credentials.json"
+    mocker.patch.object(sda, "_CLIENT_SECRET_FILE", client_secret_file)
+    mocker.patch.object(sda, "_USER_CREDENTIALS_FILE", creds_file)
+
+    mock_open = mocker.patch.object(sda, "webbrowser")
+    mocker.patch("builtins.input", return_value="auth_code_123")
+
+    mock_post = mocker.patch("scripts.setup_drive_auth.requests.post")
+    mock_post.return_value.ok = True
+    mock_post.return_value.json.return_value = {
+        "refresh_token": "rtok",
+        "access_token": "atok",
+    }
+
+    sda.main()
+
+    auth_url = mock_open.open.call_args.args[0]
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(auth_url).query)
+    assert query["scope"][0] == _SCOPE
+    assert "gmail.send" in query["scope"][0]
+    assert "drive" in query["scope"][0]

--- a/platform/photo-agent/tools/drive.py
+++ b/platform/photo-agent/tools/drive.py
@@ -71,6 +71,12 @@ def _get_access_token() -> str:
 
     Reads credentials from the user credentials file — no gws process is spawned.
     Raises RuntimeError on any failure.
+
+    Deliberately reused as the Gmail-send credential too: check_approval.py's
+    _send_approval_email() calls this directly rather than minting a separate
+    Gmail token. The underlying refresh token must therefore carry both the
+    drive and gmail.send scopes — see scripts/setup_drive_auth.py's _SCOPE
+    (issue #35). Do not assume this token is Drive-only.
     """
     creds = _load_credentials()
     try:


### PR DESCRIPTION
## Summary

Closes #35.

`check_approval.py`'s `_send_approval_email()` deliberately reuses `drive.py`'s `_get_access_token()` as its Gmail-send credential rather than maintaining a separate OAuth2 flow (see `check_approval.py:122-123`). But `setup_drive_auth.py`'s `_SCOPE` constant only requested `https://www.googleapis.com/auth/drive`, so the refresh token it minted could not authorize a Gmail `messages/send` call — producing the live HTTP 403 reported in #35.

- Widens `_SCOPE` in `platform/photo-agent/scripts/setup_drive_auth.py` to a space-separated `"https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/gmail.send"`.
- Documents in both `setup_drive_auth.py`'s module docstring/`_SCOPE` comment and `drive.py`'s `_get_access_token()` docstring that this credential is **deliberately shared** between Drive and Gmail-send, so a future reader doesn't "fix" it back to Drive-only.
- Adds `platform/photo-agent/tests/test_setup_drive_auth.py` covering the scope constant (includes both scopes, correctly space-separated) and its propagation into the OAuth2 auth URL built by `main()`.
- `_send_approval_email`'s error handling around Gmail 403s was already covered by `test_check_approval.py` (`test_send_approval_email_raises_on_http_error`, `test_send_approval_email_raises_on_token_failure`) — no changes needed there.

Scoped narrowly to the Gmail-scope fix; `check_approval.py`'s callback/`answerCallbackQuery` logic is untouched so this doesn't conflict with #31's in-flight callback-race work on the same file.

## ⚠️ Post-merge manual step required

**This PR alone does not fix the live 403.** The existing stored refresh token in `~/.config/gws/user_credentials.json` was minted under the old Drive-only scope and will keep failing Gmail sends until it's replaced. After merging, someone with access to the deployment machine must interactively re-run:

```
python3 platform/photo-agent/scripts/setup_drive_auth.py
```

and complete the OAuth2 consent flow again (Google will show the added `gmail.send` permission) so the new scope actually takes effect. This live re-auth step is intentionally **not** part of this PR.

## Test plan
- [x] `platform/photo-agent`: `python3 -m pytest -q` → 455 passed
- [x] `platform/email-agent`: `python3 -m pytest -q` → 70 passed
- [x] New tests confirm `_SCOPE` includes both `drive` and `gmail.send`, is space-separated, and reaches the auth URL query string
- [x] Post-merge: live re-run of `setup_drive_auth.py` (interactive, out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)