### PR TITLE
Fix check_approval cron-vs-callback-freshness race (issue #31)

### DIFF
--- a/platform/photo-agent/scripts/check_approval.py
+++ b/platform/photo-agent/scripts/check_approval.py
@@ -27,6 +27,19 @@ the same update stream. Plain-text admin notifications (_notify_admin) also
 use the approval bot token so the whole approve/reject interaction — button,
 tap acknowledgement, and outcome message — stays in one Telegram
 conversation, separate from Hermes's own bot conversation.
+
+Fast-ack / long-poll fix (issue #31): a callback_query's freshness window
+(~15s, Telegram-side) is far shorter than cron's once-a-minute cadence. The
+cron leg's getUpdates call already answered a matched callback before any
+approve/reject processing (see _LONG_POLL_TIMEOUT_SECONDS below and the
+answer_callback_query call in _run) — but with a plain instant poll
+(timeout=0), a tap landing between two cron ticks could sit queued for up to
+~60s before this leg ever saw it, already stale by the time it was observed.
+getUpdates now long-polls for up to _LONG_POLL_TIMEOUT_SECONDS: Telegram
+holds the connection open and delivers the tap the moment it happens, so
+answer_callback_query fires within a fraction of a second of the tap for any
+tap landing while the poll is open, instead of waiting for the next minute
+boundary.
 """
 
 import argparse
@@ -64,6 +77,13 @@ _REPO_ROOT = Path(__file__).parents[3]
 # Dedicated bot token for the entire button-callback surface (issue #29) —
 # never the same token as Hermes's TELEGRAM_BOT_TOKEN gateway poll.
 _APPROVAL_TOKEN_ENV = "TELEGRAM_APPROVAL_BOT_TOKEN"
+
+# Telegram long-poll duration (seconds) for the cron leg's getUpdates call
+# (issue #31). Telegram's own recommended ceiling for a single getUpdates
+# long-poll is ~50s; kept a little under both that and cron's 60s cadence so
+# this invocation's poll has normally finished (or been serviced) before the
+# next cron tick fires and finds the check_approval.lock still held.
+_LONG_POLL_TIMEOUT_SECONDS = 45
 
 
 def _try_acquire_check_lock() -> "IO | None":
@@ -350,7 +370,9 @@ def _run(args) -> None:
         offset = state.get_telegram_offset()
 
         try:
-            updates = telegram_api.get_updates(offset, token_env_var=_APPROVAL_TOKEN_ENV)
+            updates = telegram_api.get_updates(
+                offset, token_env_var=_APPROVAL_TOKEN_ENV, timeout=_LONG_POLL_TIMEOUT_SECONDS
+            )
         except RuntimeError as exc:
             _log.error("get_updates failed — retrying on next run: %s", exc)
             return

--- a/platform/photo-agent/tests/test_check_approval.py
+++ b/platform/photo-agent/tests/test_check_approval.py
@@ -903,7 +903,9 @@ def test_cron_get_updates_uses_approval_token(base):
     import scripts.check_approval as ca
     ca.telegram_api.get_updates.return_value = []
     main([])
-    ca.telegram_api.get_updates.assert_called_once_with(50, token_env_var="TELEGRAM_APPROVAL_BOT_TOKEN")
+    ca.telegram_api.get_updates.assert_called_once_with(
+        50, token_env_var="TELEGRAM_APPROVAL_BOT_TOKEN", timeout=ca._LONG_POLL_TIMEOUT_SECONDS
+    )
 
 
 def test_cron_answer_callback_query_uses_approval_token(base):
@@ -914,6 +916,102 @@ def test_cron_answer_callback_query_uses_approval_token(base):
     ca.telegram_api.answer_callback_query.assert_called_once_with(
         "cq_approve", text="✅ Approving...", token_env_var="TELEGRAM_APPROVAL_BOT_TOKEN"
     )
+
+
+# ---------------------------------------------------------------------------
+# Cron-vs-callback-freshness race (issue #31)
+#
+# Telegram expires a callback_query ~15s after the tap; the cron leg only
+# ran once a minute. A plain instant poll (timeout=0) could leave a tap
+# queued for up to that full minute before this leg ever saw it — already
+# stale by the time it was observed, no matter how fast the code that ran
+# afterward was. These tests simulate "answered late" (the old timeout=0
+# behaviour, reintroduced) vs "answered immediately" (long-poll + fast ack).
+# ---------------------------------------------------------------------------
+
+def test_cron_get_updates_long_polls_instead_of_instant_poll(base):
+    """Regression guard: the cron leg must not revert to an instant (timeout=0) poll.
+
+    timeout=0 is exactly the configuration that produced issue #31's race — a
+    tap landing between two cron ticks would sit queued, already stale, until
+    the next tick finally called get_updates.
+    """
+    import scripts.check_approval as ca
+    ca.telegram_api.get_updates.return_value = []
+    main([])
+    used_timeout = ca.telegram_api.get_updates.call_args.kwargs["timeout"]
+    assert used_timeout > 0
+    assert used_timeout == ca._LONG_POLL_TIMEOUT_SECONDS
+
+
+def test_long_poll_timeout_stays_under_cron_cadence(base):
+    """_LONG_POLL_TIMEOUT_SECONDS must stay under the 60s cron cadence.
+
+    A poll that ran as long as (or longer than) the cron interval would
+    overlap the next cron tick indefinitely, defeating the margin the
+    long-poll is meant to leave before the next invocation's own poll opens.
+    """
+    import scripts.check_approval as ca
+    assert 0 < ca._LONG_POLL_TIMEOUT_SECONDS < 60
+
+
+def test_answer_callback_query_not_delayed_by_slow_approve_processing(base):
+    """Simulates a callback answered 'immediately': answer_callback_query must fire
+    right after get_updates returns, before the slow approval email send even starts —
+    the ordering that keeps a borderline-fresh callback from expiring while
+    processing runs. Uses wall-clock timestamps, not just call order, so a
+    regression that interleaves slow work before the ack is actually caught.
+    """
+    import time
+    import scripts.check_approval as ca
+    ca.telegram_api.get_updates.return_value = [_APPROVE_UPDATE]
+
+    timestamps = {}
+
+    def _record_get_updates(*a, **kw):
+        timestamps["get_updates"] = time.monotonic()
+        return [_APPROVE_UPDATE]
+
+    def _record_answer(*a, **kw):
+        timestamps["answer"] = time.monotonic()
+
+    def _slow_email(*a, **kw):
+        # Simulates the "slower approve/reject processing" the issue's fix
+        # is meant to happen strictly after the ack, never before it.
+        time.sleep(0.05)
+        timestamps["email"] = time.monotonic()
+
+    ca.telegram_api.get_updates.side_effect = _record_get_updates
+    ca.telegram_api.answer_callback_query.side_effect = _record_answer
+    ca._send_approval_email.side_effect = _slow_email
+
+    main([])
+
+    assert timestamps["answer"] - timestamps["get_updates"] < 0.02, (
+        "answer_callback_query was delayed after get_updates returned"
+    )
+    assert timestamps["email"] - timestamps["answer"] >= 0.04, (
+        "slow approval processing did not run after the ack"
+    )
+
+
+def test_stale_callback_query_rejected_by_telegram_preserves_state_for_retry(base):
+    """Simulates a callback answered 'late': Telegram's actual issue #31 rejection
+    ('query is too old') is handled the same as any other answer_callback_query
+    failure — offset advances, pending approval is left intact so the admin can
+    re-tap, and no approve/reject side effect runs.
+    """
+    import scripts.check_approval as ca
+    ca.telegram_api.get_updates.return_value = [_APPROVE_UPDATE]
+    ca.telegram_api.answer_callback_query.side_effect = RuntimeError(
+        "Telegram API error: {'ok': False, 'error_code': 400, "
+        "'description': 'Bad Request: query is too old and response timeout expired or query id is invalid'}"
+    )
+    main([])
+    ca.state.set_telegram_offset.assert_called_once_with(101)
+    ca.state.clear_pending_approval.assert_not_called()
+    ca._send_approval_email.assert_not_called()
+    ca.drive.delete.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/platform/photo-agent/tests/test_telegram_api.py
+++ b/platform/photo-agent/tests/test_telegram_api.py
@@ -251,6 +251,46 @@ def test_get_updates_telegram_error_raises_runtime_error():
 
 
 # ---------------------------------------------------------------------------
+# get_updates — long-poll timeout (issue #31)
+#
+# A plain instant poll (timeout=0) can leave a callback_query queued for up
+# to a full cron cycle before check_approval.py's cron leg ever calls
+# get_updates, by which point Telegram has already expired it (~15s
+# freshness window). Passing a non-zero `timeout` makes Telegram hold the
+# connection open and deliver the update the moment it happens instead.
+# ---------------------------------------------------------------------------
+
+def test_get_updates_passes_nonzero_timeout_to_telegram_param():
+    """get_updates(timeout=N) sends N as the Telegram-side long-poll timeout param."""
+    with patch("tools.telegram_api.requests.get") as mock_get:
+        mock_get.return_value = _ok_response([])
+        get_updates(0, timeout=45)
+    params = mock_get.call_args.kwargs["params"]
+    assert params["timeout"] == 45
+
+
+def test_get_updates_requests_socket_timeout_exceeds_telegram_timeout():
+    """The requests-level socket timeout always exceeds the Telegram long-poll timeout.
+
+    Regression guard: if the socket timeout were <= the Telegram `timeout` param,
+    a legitimate long poll waiting for an update would itself raise a spurious
+    requests.Timeout before Telegram ever got a chance to respond.
+    """
+    with patch("tools.telegram_api.requests.get") as mock_get:
+        mock_get.return_value = _ok_response([])
+        get_updates(0, timeout=45)
+    assert mock_get.call_args.kwargs["timeout"] > 45
+
+
+def test_get_updates_zero_timeout_still_uses_short_socket_timeout():
+    """timeout=0 (the default) keeps the original short socket timeout behaviour."""
+    with patch("tools.telegram_api.requests.get") as mock_get:
+        mock_get.return_value = _ok_response([])
+        get_updates(0)
+    assert mock_get.call_args.kwargs["timeout"] == 10
+
+
+# ---------------------------------------------------------------------------
 # Error handling — shared
 # ---------------------------------------------------------------------------
 

--- a/platform/photo-agent/tools/telegram_api.py
+++ b/platform/photo-agent/tools/telegram_api.py
@@ -3,7 +3,7 @@ Telegram Bot API wrapper for the photo-video agent.
 
 Handles every Telegram operation the photo-agent scripts need: plain-text
 messages, inline keyboards (reply_markup), callback dismissal, and update
-polling.
+polling (optionally long-polling, via get_updates' `timeout` — see issue #31).
 
 Bot token is read from TELEGRAM_BOT_TOKEN in the environment by default.
 Every function accepts an optional token_env_var to read a different bot
@@ -184,23 +184,29 @@ def edit_message_reply_markup(
     logger.debug("edit_message_reply_markup: ok")
 
 
-def get_updates(offset: int, token_env_var: str = "TELEGRAM_BOT_TOKEN") -> list[dict]:
+def get_updates(offset: int, token_env_var: str = "TELEGRAM_BOT_TOKEN", timeout: int = 0) -> list[dict]:
     """Poll getUpdates with the given offset. Returns the raw list of update objects.
 
-    The Telegram timeout param is fixed at 0 (return immediately). The requests
-    socket timeout (10 s) must exceed the Telegram timeout param to avoid a
-    spurious Timeout exception.
+    timeout is the Telegram long-poll duration in seconds: Telegram holds the
+    connection open and returns as soon as an update is available, or after
+    `timeout` seconds if none arrives. Defaults to 0 (return immediately with
+    whatever is already queued), which preserves the historical behaviour for
+    any caller that doesn't pass it.
+
+    The requests socket timeout is always `timeout + 10`, so it comfortably
+    exceeds the Telegram-side timeout param and a legitimate long poll is
+    never mistaken for a network failure.
     """
-    logger.debug("get_updates: offset=%d", offset)
+    logger.debug("get_updates: offset=%d timeout=%d", offset, timeout)
     try:
         response = requests.get(
             _url("getUpdates", token_env_var),
-            params={"offset": offset, "timeout": 0},
-            timeout=10,
+            params={"offset": offset, "timeout": timeout},
+            timeout=timeout + 10,
         )
     except requests.exceptions.RequestException as exc:
         raise RuntimeError(f"Telegram request failed: {_redact_token(str(exc), token_env_var)}") from exc
     data = _check(response)
     updates: list[dict] = data.get("result", [])
-    logger.info("get_updates: offset=%d count=%d", offset, len(updates))
+    logger.info("get_updates: offset=%d timeout=%d count=%d", offset, timeout, len(updates))
     return updates


### PR DESCRIPTION
## Summary

Closes #31.

Telegram expires a `callback_query` ~15s after the tap, but `check_approval.py`'s cron leg polled `getUpdates` instantly (`timeout=0`) once a minute. A tap landing between two cron ticks could sit queued for up to 60s before the leg ever saw it — already stale by the time it was observed, regardless of how fast the code that ran afterward was.

`answer_callback_query` was already called before any approve/reject processing (email send, Drive delete, etc.) — the existing `test_*_answer_callback_query_called_first` tests confirm that ordering was already correct. The actual gap was on the *observation* side, confirmed by reading `telegram_api.get_updates()`: it always polled with Telegram's own `timeout=0`, i.e. "return immediately with whatever's already queued," never holding the connection open.

### Fix

- `telegram_api.get_updates()` gains an optional `timeout` param — the Telegram-side long-poll duration in seconds. Default stays `0`, preserving existing behaviour for any other caller. The requests-level socket timeout is always `timeout + 10`, so a legitimate long poll is never mistaken for a network failure (this coupling was already documented in the function's docstring for the old fixed values).
- `check_approval.py`'s cron leg now calls `get_updates(..., timeout=_LONG_POLL_TIMEOUT_SECONDS)` with `_LONG_POLL_TIMEOUT_SECONDS = 45` — under Telegram's own recommended long-poll ceiling and under cron's 60s cadence, so each invocation's poll has normally finished before the next cron tick fires. Telegram now delivers a tap the moment it happens (while the poll is open) instead of waiting for the next minute boundary, so `answer_callback_query` fires within a fraction of a second of the actual tap for the large majority of the polling window.

This is the issue's own suggested candidate fix (fast ack), realized in code as: hold the poll open (long-poll) so "receipt" happens close to the tap itself, and keep answering before any slow work (already true).

Out of scope, deliberately untouched: issue #35 (Gmail email-sending in this same file) — nothing here should make that harder to fix later; the only change to `_send_approval_email`'s call site is that it now runs strictly after the ack, which was already the case.

## Test plan

- [x] `platform/photo-agent/tests/test_check_approval.py` — updated the existing token-isolation assertion for the new `timeout=` kwarg, and added:
  - `test_cron_get_updates_long_polls_instead_of_instant_poll` — regression guard against reverting to `timeout=0`.
  - `test_long_poll_timeout_stays_under_cron_cadence` — timeout stays under 60s.
  - `test_answer_callback_query_not_delayed_by_slow_approve_processing` — wall-clock timing proof (not just call order) that the ack isn't delayed by slow approval-email processing.
  - `test_stale_callback_query_rejected_by_telegram_preserves_state_for_retry` — the literal "query is too old" Telegram error text degrades gracefully (offset advances, pending approval preserved, no approve/reject side effect).
- [x] `platform/photo-agent/tests/test_telegram_api.py` — added tests for the new `timeout` param: passed through to the Telegram query param, requests socket timeout exceeds it, and `timeout=0` default keeps the old short socket timeout.
- [x] Full suite green: `platform/photo-agent` 458 passed, `platform/email-agent` 70 passed (untouched, run for completeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)