### PR TITLE
Scaffold mercury: Anthropic-backed demo customer (Option C)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 
 # Name of the active client directory under clients/.
 # Must match an existing directory: clients/{CLIENT_NAME}/
-# Example: _demo, _construction_co
+# Example: _demo, _construction_co, mercury
 CLIENT_NAME=
 
 # Absolute path to the FieldKit repo root on this machine.

--- a/clients/mercury/.specify/README.md
+++ b/clients/mercury/.specify/README.md
@@ -1,0 +1,41 @@
+# Mercury — Spec-Kit Directory
+
+This directory holds all spec-kit artifacts for the Mercury demo customer.
+
+## Structure
+
+```
+.specify/
+├── constitution.md         ← client principles (created by /speckit-constitution)
+├── feature.json            ← active feature pointer (managed by spec-kit)
+├── {NNN}-{feature-name}/   ← one directory per feature
+│   ├── spec.md             ← requirements (/speckit-specify)
+│   ├── clarify.md          ← Q&A (/speckit-clarify)
+│   ├── plan.md             ← technical plan (/speckit-plan)
+│   ├── sequence-diagram.md ← Mermaid diagram (/speckit-plan)
+│   ├── tasks.md            ← task breakdown (/speckit-tasks)
+│   └── features/
+│       └── *.feature       ← Gherkin acceptance tests (/speckit-tasks)
+└── README.md               ← this file
+```
+
+## Spec-Kit Workflow
+
+```
+/speckit-constitution  →  Establish client principles
+/speckit-specify       →  Write feature spec
+/speckit-clarify       →  Resolve ambiguities
+/speckit-plan          →  Technical plan + sequence diagram
+/speckit-tasks         →  Task breakdown + Gherkin features
+/speckit-implement     →  Build with AI assistance
+```
+
+## Current Features
+
+| ID | Feature | Status |
+|----|---------|--------|
+| — | *(no numbered feature yet — this client reuses `platform/photo-agent`'s existing engine end to end; no client-specific spec has been needed so far)* | — |
+
+---
+
+*Specs are technology-agnostic — they define what and why, not how.*

--- a/clients/mercury/.specify/constitution.md
+++ b/clients/mercury/.specify/constitution.md
@@ -179,9 +179,9 @@ privacy.
 - No feature considered complete without passing tests
 - Test suite included in client handoff
 - Mercury has no client-specific test files by design — it reuses `platform/photo-agent`'s
-  and `platform/email-agent`'s existing test suites, which are already parametrized by
-  `CLIENT_NAME`/`FIELDKIT_DATA_DIR`/`FIELDKIT_LOG_DIR` rather than hardcoded per client (same
-  pattern `_demo` follows)
+  and `platform/email-agent`'s existing test suites, which are already environment-driven and
+  client-agnostic (configured via `CLIENT_NAME`/`FIELDKIT_DATA_DIR`/`FIELDKIT_LOG_DIR` env
+  vars) rather than hardcoded per client (same pattern `_demo` follows)
 
 ### Error Handling Philosophy
 - Retry failed operations (email send, API calls)

--- a/clients/mercury/.specify/constitution.md
+++ b/clients/mercury/.specify/constitution.md
@@ -150,11 +150,19 @@ privacy.
 ### Hermes Integration
 - Self-hosted Hermes Agent runtime on Mac Mini
 - Model calls route to **Anthropic's API only** — this is explicit, not inherited from a
-  repo-wide default, and is enforced via a dedicated `mercury` gateway profile
-  (`hermes gateway install --profile mercury`, or equivalent — see PR description for the
-  exact live setup checklist)
-- `ANTHROPIC_API_KEY` lives in the `mercury` profile's own `~/.hermes/.env` (or equivalent
-  profile-scoped secret store), never in this repo
+  repo-wide default, and is enforced via a dedicated `mercury` Hermes profile, separate
+  from `_demo`'s default profile
+- Verified live against the installed Hermes CLI (v0.20.5): there is no `--profile` flag on
+  `config set`/`gateway install`/`doctor`. Profile targeting is `hermes profile create
+  mercury` once, then `hermes profile use mercury` (a sticky switch) before running
+  `config set`/`gateway install`/`doctor` for that profile — see PR description for the
+  exact live setup checklist
+- `ANTHROPIC_API_KEY`, `TELEGRAM_BOT_TOKEN` (Hermes gateway bot), and
+  `TELEGRAM_ALLOWED_USERS` live in `~/.hermes/profiles/mercury/.env`; `skills.external_dirs`
+  (pointing at `platform/photo-agent/skills`, same path `_demo`'s default profile already
+  uses) lives in `~/.hermes/profiles/mercury/config.yaml` — none of this in this repo
+- `gateway install` while `mercury` is active installs a separate launchd service
+  (`ai.hermes.gateway-mercury.plist`), independent of `_demo`'s default-profile gateway
 - Model selection based on task complexity
 - Token usage monitoring for cost tracking
 

--- a/clients/mercury/.specify/constitution.md
+++ b/clients/mercury/.specify/constitution.md
@@ -1,0 +1,214 @@
+# Mercury — Project Constitution
+
+## Introduction
+
+This constitution governs the Mercury demo customer — FieldKit's second reference
+implementation, created alongside `_demo` to validate per-client model-provider
+configuration. All values marked `[DEMO]` are placeholders — replace with real values when
+onboarding an actual client. This document otherwise mirrors `_demo`'s constitution; see
+[`clients/_demo/.specify/constitution.md`](../../_demo/.specify/constitution.md) for the
+sibling reference.
+
+**Last Updated:** 2026-08-25
+**Status:** Reference / Scaffolded — live credentials pending
+**Deployment Model:** Mac Mini (on-premise, interim — see `platform/.specify/003-hermes-runtime/spec.md`)
+**AI Provider:** Hermes Agent (self-hosted runtime); **explicitly Anthropic-backed**, routed
+through a dedicated `mercury` Hermes gateway profile (not the shared/default profile `_demo`
+uses) — see Hermes Integration below.
+**Development Approach:** Phased implementation
+
+---
+
+## Deployment Architecture
+
+### Mac Mini Model (interim)
+
+**Hosting & Ownership:**
+- FieldKit provides Mac Mini for development and deployment, shared with `_demo` during the
+  interim development period (both demo customers currently run on the same physical box)
+- A production client deployment runs exactly one client per installation — this
+  shared-box arrangement is a dev/demo-only artifact, not the target production topology
+- Upon a real client engagement reaching completion, hardware/cloud handoff follows the same
+  model as `_demo` — see `platform/.specify/003-hermes-runtime/spec.md` for the Mac Mini →
+  Cloud pivot roadmap
+
+**Implications:**
+- AI inference routes to Anthropic's API via Hermes Agent, through the `mercury` gateway
+  profile specifically — kept separate from `_demo`'s profile so the two demo customers can
+  validate genuinely different providers concurrently without cross-talk
+- Non-AI data storage/ownership model follows the same not-yet-finalized post-pivot state as
+  `_demo` (see `_demo`'s constitution for the caveat)
+
+---
+
+## Core Values
+
+### 1. Customer Privacy & Trust
+
+**Principle:** Customer data and job-site information must never appear in public-facing
+content without explicit consent.
+
+**Implementation Requirements:**
+- [x] All metadata (GPS, timestamps, camera info) stripped from photos before posting
+- [x] Human verification required for all customer-facing content
+- [x] All customer data stored locally on Mac Mini (not cloud) `[DEMO]`
+
+---
+
+### 2. Cost Governance & Sustainability
+
+**Principle:** AI spending must be predictable, controlled, and sustainable for a small
+business.
+
+**Budget Constraints:**
+- **Hard Daily Limit:** $5.00 USD per day `[DEMO]`
+- **Alert Threshold:** 75% of daily budget consumed
+- **Enforcement:** System automatically pauses AI operations when daily limit reached
+
+**Hermes Cost Model:**
+- Self-hosted Hermes Agent supervisor process (one-time hardware cost), running its own
+  `mercury` gateway profile separate from `_demo`'s
+- Per-token Anthropic API costs
+- External API costs only for other services that can't be self-hosted
+
+**Priority During Budget Constraints:**
+1. Telegram approval flow (must always run)
+2. Facebook posting
+
+---
+
+### 3. Human Oversight & Quality Control
+
+**Principle:** AI assists human judgment; it does not replace it. All customer-facing content
+requires human review.
+
+**Approval Requirements:**
+- ALL customer-facing content requires admin approval before publication
+- Social media posts (captions, images/video)
+
+**Approval Workflow:**
+- Agent sends draft to admin via Telegram
+- Admin can approve, request revisions, or reject
+- System tracks approval history locally
+
+---
+
+### 4. Operational Priorities
+
+**Phase 1 (Current):** Photo-approval e2e cycle, Anthropic-backed
+- **Goal:** One full trigger → photo processing → Telegram approval → confirmed-post cycle,
+  verified live with a human, proving the per-client provider config works end to end
+- **Priority:** This client exists specifically to validate FR-004/FR-005; scope stays
+  narrow until that's proven
+
+---
+
+### 5. Data Integrity & Preservation
+
+**Principle:** Business data is valuable and should be preserved. Local storage ensures
+control.
+
+**Data Storage:**
+- All data stored on Mac Mini, under `clients/mercury/data` and `clients/mercury/logs`
+- No cloud storage except Gmail (email), Google Drive (photo intake), and Telegram
+  (notifications)
+- Data ownership: client owns all data on their Mac Mini `[DEMO]`
+
+**External Services Used:**
+- [x] Gmail (agent email inbox) `[DEMO]`
+- [x] Google Drive (photo intake) `[DEMO]`
+- [x] Telegram (admin notifications and commands) `[DEMO]` — dedicated bot, separate from
+  `_demo`'s and `_construction_co`'s, per the existing convention (see `.env.example`)
+- [x] Facebook (posting) `[DEMO]`
+
+---
+
+## Feature-Specific Principles
+
+### Social Media Management
+
+**Philosophy:** Every post must look professionally crafted and never expose customer
+privacy.
+
+**Key Principles:**
+- Before/after format showcases work quality without identifying customers
+- All metadata stripped from photos before any processing
+- No post goes live without admin approval
+
+**Platforms:** Instagram, Facebook `[DEMO — mirrors _demo's scope]`
+
+---
+
+## Technical Constraints
+
+### Infrastructure Requirements
+- Mac Mini M-series (shared with `_demo` during the interim dev period)
+- Reliable internet connection (always-on)
+- Dedicated Gmail account for agent email (`agent@[DEMO].com`)
+- macOS for deployment
+
+### Hermes Integration
+- Self-hosted Hermes Agent runtime on Mac Mini
+- Model calls route to **Anthropic's API only** — this is explicit, not inherited from a
+  repo-wide default, and is enforced via a dedicated `mercury` gateway profile
+  (`hermes gateway install --profile mercury`, or equivalent — see PR description for the
+  exact live setup checklist)
+- `ANTHROPIC_API_KEY` lives in the `mercury` profile's own `~/.hermes/.env` (or equivalent
+  profile-scoped secret store), never in this repo
+- Model selection based on task complexity
+- Token usage monitoring for cost tracking
+
+### Admin Access
+- Single admin user (Phase 1)
+- Preferred interface: Telegram (primary), email (fallback)
+
+### Testing Requirements
+- All features built using test-driven development
+- Unit tests required for all functions and components
+- Integration tests required for all end-to-end feature flows
+- No feature considered complete without passing tests
+- Test suite included in client handoff
+- Mercury has no client-specific test files by design — it reuses `platform/photo-agent`'s
+  and `platform/email-agent`'s existing test suites, which are already parametrized by
+  `CLIENT_NAME`/`FIELDKIT_DATA_DIR`/`FIELDKIT_LOG_DIR` rather than hardcoded per client (same
+  pattern `_demo` follows)
+
+### Error Handling Philosophy
+- Retry failed operations (email send, API calls)
+- Log all errors locally
+- Notify admin via Telegram for critical failures
+- Graceful degradation when services are unavailable
+
+---
+
+## Decision-Making Framework
+
+When conflicts arise, resolve in this order:
+
+1. **Customer Privacy** — privacy concerns override all other considerations
+2. **System Reliability** — system must be stable and always available
+3. **Budget Constraints** — stay within cost limits
+4. **Human Oversight** — require approval for customer-facing content
+5. **Operational Priorities** — follow the phase sequence
+6. **Quality Standards** — professional, accurate, helpful
+7. **Development Efficiency** — simple, maintainable solutions
+
+---
+
+## Hardware Transfer Plan
+
+**Upon Project Completion:**
+
+1. **System Validation** — all agreed features working, client satisfied
+2. **Knowledge Transfer** — training session, documentation handoff, admin guide
+3. **Physical Transfer** — Mac Mini delivered to client location, connectivity verified
+4. **Post-Transfer Support** — 30-day support period included
+5. **Long-Term** — client owns and operates system; source code provided
+
+---
+
+*Established: 2026-08-25*
+*Authority: Mercury (demo customer — reference implementation)*
+*Framework: FieldKit*
+*Deployment: Mac Mini (on-premise, interim)*
+*AI Provider: Hermes Agent (Anthropic-backed, dedicated `mercury` profile)*

--- a/clients/mercury/.specify/constitution.md
+++ b/clients/mercury/.specify/constitution.md
@@ -152,11 +152,13 @@ privacy.
 - Model calls route to **Anthropic's API only** — this is explicit, not inherited from a
   repo-wide default, and is enforced via a dedicated `mercury` Hermes profile, separate
   from `_demo`'s default profile
-- Verified live against the installed Hermes CLI (v0.20.5): there is no `--profile` flag on
-  `config set`/`gateway install`/`doctor`. Profile targeting is `hermes profile create
-  mercury` once, then `hermes profile use mercury` (a sticky switch) before running
-  `config set`/`gateway install`/`doctor` for that profile — see PR description for the
-  exact live setup checklist
+- Verified live against the installed Hermes CLI (v0.20.5): profile targeting uses
+  `hermes -p mercury <command>` (undocumented but confirmed real — scopes a single
+  invocation to that profile, leaves the global sticky default untouched), after a one-time
+  `hermes profile create mercury`. `hermes profile use mercury` (a separate, sticky
+  global-default switch) also works but was deliberately not used for the live setup
+  checklist — safer for a human pasting commands one at a time — see PR description for the
+  exact sequence
 - `ANTHROPIC_API_KEY`, `TELEGRAM_BOT_TOKEN` (Hermes gateway bot), and
   `TELEGRAM_ALLOWED_USERS` live in `~/.hermes/profiles/mercury/.env`; `skills.external_dirs`
   (pointing at `platform/photo-agent/skills`, same path `_demo`'s default profile already

--- a/clients/mercury/README.md
+++ b/clients/mercury/README.md
@@ -1,0 +1,77 @@
+# Mercury — FieldKit Demo Customer (Anthropic-backed)
+
+**Client:** Mercury (demo customer — not a real engagement)
+**Industry:** General / Reference
+**Location:** N/A
+**Status:** In Progress — Scaffolded, live credentials pending
+**Deployment:** Mac Mini (on-premise, interim — see `platform/.specify/003-hermes-runtime/spec.md`)
+**AI Provider:** Anthropic — explicit, not inherited by default. Model calls route through a
+dedicated Hermes gateway profile (`mercury`), separate from `_demo`'s profile, so this
+customer can run side by side with a future OpenAI-backed demo customer (#12) without either
+one's provider choice leaking into the other. See
+[`platform/docs/hermes/02-gateway-setup.md`](../../platform/docs/hermes/02-gateway-setup.md)
+for the shared-gateway background and the per-client provider question this client resolves.
+
+---
+
+## Overview
+
+`clients/mercury/` is FieldKit's second reference implementation, created to prove out
+per-client model-provider configuration (FR-004/FR-005,
+[`platform/.specify/003-hermes-runtime/spec.md`](../../platform/.specify/003-hermes-runtime/spec.md)
+Story 2) with a real, working example — not just a spec claim. It mirrors `_demo`'s full
+pipeline (video → Telegram approval → Facebook) so the two demo customers are directly
+comparable except for provider. It uses clearly fake credentials and placeholder data; it is
+not a real client engagement.
+
+Real client implementations live in separate private repositories. See
+[`clients/README.md`](../README.md) for the architecture decision behind this.
+
+---
+
+## Feature Status
+
+| Feature | Spec | Clarify | Plan | Build | Live |
+|---------|------|---------|------|-------|------|
+| Photo-approval e2e cycle (Anthropic-backed) | — | — | — | ✅ Scaffolded | ⏳ Deferred — see PR checklist |
+
+Live end-to-end verification (trigger → photo processing → Telegram approval → confirmed
+post) is deliberately **not** run as part of scaffolding this client. Everything needed to
+run it is in place (client directory, `.env.example`, e2e test rig reuse via
+`platform/photo-agent/scripts/run_e2e_test.py`); the live run itself is a separate, deferred
+step done with the human once real credentials are provisioned.
+
+---
+
+## Governance
+
+All decisions are governed by the project constitution:
+→ [`.specify/constitution.md`](.specify/constitution.md)
+
+Platform-level engine specs:
+→ [`platform/.specify/002-photo-agent/spec.md`](../../platform/.specify/002-photo-agent/spec.md)
+→ [`platform/.specify/003-hermes-runtime/spec.md`](../../platform/.specify/003-hermes-runtime/spec.md)
+
+---
+
+## Development Workflow
+
+| Step | Status |
+|------|--------|
+| Constitution | ✅ |
+| Specification | ⏳ |
+| Clarification | ⏳ |
+| Technical Planning | ⏳ |
+| Task Breakdown | ⏳ |
+| Implementation | ✅ Scaffolded (reuses `platform/photo-agent` engine, no client-specific code) |
+| Production | ⏳ |
+
+---
+
+## Next Steps
+
+1. [x] Fill in constitution
+2. [x] Scaffold client directory and `.env.example` from `_template`/`_demo` convention
+3. [ ] Provision live credentials (see PR description for the exact checklist)
+4. [ ] Run one live end-to-end photo-approval cycle with the human
+5. [ ] Run `/speckit.specify` if/when this client grows beyond the reference e2e cycle

--- a/clients/mercury/src/photo-agent/.env.example
+++ b/clients/mercury/src/photo-agent/.env.example
@@ -1,0 +1,97 @@
+# Mercury — photo-agent environment variables
+# Copy this file to .env and fill in all values before running any script.
+# NEVER commit .env to version control.
+# After creating .env, set restrictive permissions: chmod 600 .env
+#
+# Pipeline scope for mercury: full pipeline, mirrors _demo — video generation →
+# Telegram approval → Facebook post. Mercury exists to validate per-client model-provider
+# routing (see AI Provider note below), not a different pipeline shape, so it stays
+# feature-complete like _demo rather than scoped like _construction_co.
+#
+# ---------------------------------------------------------------------------
+# AI Provider — Anthropic (explicit, not inherited by default)
+# ---------------------------------------------------------------------------
+# This file does NOT contain ANTHROPIC_API_KEY. The photo-agent pipeline scripts below
+# are deterministic Python (no LLM calls) — model routing applies only to Hermes's
+# chat-gateway skill dispatch (process_photos / check_approval on-demand commands).
+# Mercury's model provider is pinned to Anthropic via a dedicated Hermes gateway profile
+# (`mercury`), configured on the Mac Mini, separate from _demo's profile:
+#   hermes gateway install --profile mercury --start-now --start-on-login
+#   hermes config set model.provider anthropic --profile mercury
+#   hermes config set model.default claude-sonnet-5 --profile mercury
+# ANTHROPIC_API_KEY for this client lives in that profile's own ~/.hermes/.env (or
+# equivalent profile-scoped secret store) — never in this repo. See
+# platform/docs/hermes/02-gateway-setup.md for the shared-gateway background, and the PR
+# description for this feature for the exact live setup checklist.
+
+# Gmail address the agent uses to send the approval email
+AGENT_EMAIL=  # required — separate Gmail account from _demo and _construction_co
+
+# Recipient of the approval email
+ADMIN_EMAIL=  # required
+
+# Admin's Telegram chat ID (find your chat ID via @userinfobot). Same numeric
+# value works for both bots below — a private DM's chat_id is the admin's own
+# user id, independent of which bot the conversation is with.
+ADMIN_TELEGRAM_CHAT_ID=  # required
+
+# Telegram bot token used by Hermes's gateway (conversational commands).
+# Must be a separate bot registration from _demo's and _construction_co's.
+TELEGRAM_BOT_TOKEN=  # required
+
+# Telegram bot token for a SECOND, dedicated bot — used only for the
+# approval message and its Approve/Reject buttons, getUpdates polling for
+# the tap, and the resulting outcome notification. Must be a different bot
+# (separate BotFather registration) from TELEGRAM_BOT_TOKEN: this is what
+# keeps check_approval.py's cron leg from racing Hermes's own continuous
+# getUpdates long-poll for the same offset (issue #29). Send /start to this
+# bot once so it can message ADMIN_TELEGRAM_CHAT_ID.
+TELEGRAM_APPROVAL_BOT_TOKEN=  # required
+
+# Google Drive ID of the root project folder (separate Drive folder from other clients)
+DRIVE_ROOT_FOLDER_ID=  # required
+
+# Display duration per photo in seconds (default: 4)
+SECONDS_PER_PHOTO=4
+
+# Local temp directory for downloaded photos and the generated video
+VIDEO_TMP_DIR=data/photo-agent/tmp
+
+# Path to Drive OAuth credentials JSON (ADC format — client_id, client_secret, refresh_token).
+# Default: ~/.config/gws/user_credentials.json
+# Create once after gws auth login:
+#   gws auth export 2>/dev/null | python3 -c "
+#     import sys, json; raw = sys.stdin.read()
+#     print(json.dumps(json.loads(raw[raw.find('{'):]), indent=2))
+#   " > ~/.config/gws/user_credentials.json && chmod 600 ~/.config/gws/user_credentials.json
+# GOOGLE_USER_CREDENTIALS_FILE=~/.config/gws/user_credentials.json
+
+# Client-scoped data directory — required; platform scripts raise RuntimeError if unset
+FIELDKIT_DATA_DIR=/path/to/fieldkit/clients/mercury/data
+
+# Client-scoped log directory — required; platform scripts raise RuntimeError if unset
+FIELDKIT_LOG_DIR=/path/to/fieldkit/clients/mercury/logs
+
+# Operational note: logs/photo-agent.log is append-only and unbounded.
+# Rotate manually or configure logrotate if disk space is a concern.
+
+# ---------------------------------------------------------------------------
+# Facebook Page connection — Feature 003
+# FB_APP_ID and FB_APP_SECRET are used ONLY by generate_auth_link.py (admin, one-time).
+# FB_PAGE_ID and FB_PAGE_ACCESS_TOKEN are written automatically by generate_auth_link.py.
+# ---------------------------------------------------------------------------
+
+# Meta Developer App ID (required before running generate_auth_link.py)
+FB_APP_ID=
+
+# Meta Developer App secret (required before running generate_auth_link.py; never used by cron)
+FB_APP_SECRET=
+
+# Facebook Page ID — written by generate_auth_link.py (numeric string, e.g. 123456789)
+FB_PAGE_ID=
+
+# Permanent Facebook Page access token — written by generate_auth_link.py; used by upload cron
+FB_PAGE_ACCESS_TOKEN=
+
+# OAuth redirect URI — override if using a port other than 8080
+# FB_REDIRECT_URI=http://localhost:8080/callback

--- a/clients/mercury/src/photo-agent/.env.example
+++ b/clients/mercury/src/photo-agent/.env.example
@@ -8,21 +8,46 @@
 # routing (see AI Provider note below), not a different pipeline shape, so it stays
 # feature-complete like _demo rather than scoped like _construction_co.
 #
+# IMPORTANT: this file alone is not enough to run mercury's scripts. All platform scripts
+# (process_photos.py, run_e2e_test.py, etc.) load the fieldkit repo-root .env FIRST to read
+# CLIENT_NAME, and only then load this client-scoped .env. Set, in fieldkit/.env (repo root,
+# not this file):
+#   CLIENT_NAME=mercury
+#   FIELDKIT_ROOT=/absolute/path/to/fieldkit
+# Without this, scripts run against whichever client is currently selected — not mercury.
+#
 # ---------------------------------------------------------------------------
 # AI Provider — Anthropic (explicit, not inherited by default)
 # ---------------------------------------------------------------------------
 # This file does NOT contain ANTHROPIC_API_KEY. The photo-agent pipeline scripts below
 # are deterministic Python (no LLM calls) — model routing applies only to Hermes's
 # chat-gateway skill dispatch (process_photos / check_approval on-demand commands).
-# Mercury's model provider is pinned to Anthropic via a dedicated Hermes gateway profile
-# (`mercury`), configured on the Mac Mini, separate from _demo's profile:
-#   hermes gateway install --profile mercury --start-now --start-on-login
-#   hermes config set model.provider anthropic --profile mercury
-#   hermes config set model.default claude-sonnet-5 --profile mercury
-# ANTHROPIC_API_KEY for this client lives in that profile's own ~/.hermes/.env (or
-# equivalent profile-scoped secret store) — never in this repo. See
+#
+# Mercury's model provider is pinned to Anthropic via a dedicated Hermes profile
+# (`mercury`), configured on the Mac Mini, separate from _demo's (default) profile.
+# Verified live against the installed Hermes CLI (v0.20.5) — there is no `--profile`
+# flag on `config set`/`gateway install`/`doctor`; profile targeting is a sticky
+# switch via `hermes profile use`:
+#   hermes profile create mercury --no-alias
+#   hermes profile use mercury
+#   hermes config set model.provider anthropic
+#   hermes config set model.default claude-sonnet-5
+#   hermes config set skills.external_dirs '["~/src/fieldkit/platform/photo-agent/skills"]'
+#   # then edit ~/.hermes/profiles/mercury/.env directly to add:
+#   #   ANTHROPIC_API_KEY=...
+#   #   TELEGRAM_BOT_TOKEN=...        (mercury's Hermes gateway bot — distinct from
+#   #                                  TELEGRAM_APPROVAL_BOT_TOKEN below, which the
+#   #                                  cron leg uses, not Hermes)
+#   #   TELEGRAM_ALLOWED_USERS=...    (admin's Telegram user id)
+#   hermes gateway install --start-now --start-on-login
+#   hermes doctor    # -> Anthropic API check should pass for this profile
+#   hermes profile use default    # switch back — sticky, affects the next `hermes` call
+# `gateway install` while `mercury` is the active profile installs a separate launchd
+# service (ai.hermes.gateway-mercury.plist), independent of _demo's default-profile
+# gateway. ANTHROPIC_API_KEY for this client lives in
+# ~/.hermes/profiles/mercury/.env — never in this repo. See
 # platform/docs/hermes/02-gateway-setup.md for the shared-gateway background, and the PR
-# description for this feature for the exact live setup checklist.
+# description for this feature for the full live setup checklist.
 
 # Gmail address the agent uses to send the approval email
 AGENT_EMAIL=  # required — separate Gmail account from _demo and _construction_co

--- a/clients/mercury/src/photo-agent/.env.example
+++ b/clients/mercury/src/photo-agent/.env.example
@@ -10,10 +10,10 @@
 #
 # IMPORTANT: this file alone is not enough to run mercury's scripts. All platform scripts
 # (process_photos.py, run_e2e_test.py, etc.) load the fieldkit repo-root .env FIRST to read
-# CLIENT_NAME, and only then load this client-scoped .env. Set, in fieldkit/.env (repo root,
-# not this file):
-#   CLIENT_NAME=mercury
-#   FIELDKIT_ROOT=/absolute/path/to/fieldkit
+# CLIENT_NAME, and only then load this client-scoped .env. Do NOT permanently overwrite the
+# repo-root .env's CLIENT_NAME — _demo's cron jobs read that same file live on this Mac Mini.
+# Instead, prefix each invocation with an inline override:
+#   CLIENT_NAME=mercury FIELDKIT_ROOT=/absolute/path/to/fieldkit python3 platform/photo-agent/scripts/run_e2e_test.py --duration 20
 # Without this, scripts run against whichever client is currently selected — not mercury.
 #
 # ---------------------------------------------------------------------------
@@ -25,26 +25,30 @@
 #
 # Mercury's model provider is pinned to Anthropic via a dedicated Hermes profile
 # (`mercury`), configured on the Mac Mini, separate from _demo's (default) profile.
-# Verified live against the installed Hermes CLI (v0.20.5) — there is no `--profile`
-# flag on `config set`/`gateway install`/`doctor`; profile targeting is a sticky
-# switch via `hermes profile use`:
+# Verified live against the installed Hermes CLI (v0.20.5). Hermes has two real,
+# coexisting profile-targeting mechanisms:
+#   - `hermes profile use <name>` — a STICKY switch to the global default profile;
+#     persists across every later `hermes` invocation until switched back. Live-verified.
+#   - `hermes -p <name> <command>` — scopes a SINGLE invocation to that profile only,
+#     undocumented (absent from --help) but live-verified real and working; leaves the
+#     sticky default untouched.
+# Using `-p` per-command below — safer for a checklist run command-by-command (no
+# lingering state to forget), and consistent with the sibling OpenAI-backed client's setup:
 #   hermes profile create mercury --no-alias
-#   hermes profile use mercury
-#   hermes config set model.provider anthropic
-#   hermes config set model.default claude-sonnet-5
-#   hermes config set skills.external_dirs '["~/src/fieldkit/platform/photo-agent/skills"]'
+#   hermes -p mercury config set model.provider anthropic
+#   hermes -p mercury config set model.default claude-sonnet-5
+#   hermes -p mercury config set skills.external_dirs '["~/src/fieldkit/platform/photo-agent/skills"]'
 #   # then edit ~/.hermes/profiles/mercury/.env directly to add:
 #   #   ANTHROPIC_API_KEY=...
 #   #   TELEGRAM_BOT_TOKEN=...        (mercury's Hermes gateway bot — distinct from
 #   #                                  TELEGRAM_APPROVAL_BOT_TOKEN below, which the
 #   #                                  cron leg uses, not Hermes)
 #   #   TELEGRAM_ALLOWED_USERS=...    (admin's Telegram user id)
-#   hermes gateway install --start-now --start-on-login
-#   hermes doctor    # -> Anthropic API check should pass for this profile
-#   hermes profile use default    # switch back — sticky, affects the next `hermes` call
-# `gateway install` while `mercury` is the active profile installs a separate launchd
-# service (ai.hermes.gateway-mercury.plist), independent of _demo's default-profile
-# gateway. ANTHROPIC_API_KEY for this client lives in
+#   hermes -p mercury gateway install --start-now --start-on-login
+#   hermes -p mercury doctor    # -> Anthropic API check should pass for this profile
+# `gateway install` installs a separate launchd service (ai.hermes.gateway-mercury.plist),
+# independent of _demo's default-profile gateway — live-verified it starts/stops/uninstalls
+# without touching _demo's running gateway. ANTHROPIC_API_KEY for this client lives in
 # ~/.hermes/profiles/mercury/.env — never in this repo. See
 # platform/docs/hermes/02-gateway-setup.md for the shared-gateway background, and the PR
 # description for this feature for the full live setup checklist.


### PR DESCRIPTION
Part of #11

## Summary

Scaffolds `clients/mercury/` as FieldKit's second demo customer, per `platform/.specify/003-hermes-runtime/spec.md` Story 2 (FR-004/FR-005) — validating per-client model-provider configuration alongside `_demo`.

- `clients/mercury/` scaffolded from `clients/_template/`, following the same convention `_demo`/`_construction_co` used (README.md, `.specify/constitution.md`, `.specify/README.md`, `src/photo-agent/.env.example`).
- Mirrors `_demo`'s **full** pipeline (video → Telegram approval → Facebook), not `_construction_co`'s scoped one, so the two demo customers are directly comparable except for provider.
- Model provider is **explicit, not assumed**: `clients/mercury/.specify/constitution.md` and `clients/mercury/src/photo-agent/.env.example` both call out that mercury is pinned to Anthropic via a dedicated Hermes profile (`mercury`), separate from `_demo`'s (default) profile. `ANTHROPIC_API_KEY` is never a repo-tracked value.
- No client-specific test files added. `platform/photo-agent`'s and `platform/email-agent`'s existing suites are already environment-driven/client-agnostic (configured via `CLIENT_NAME`/`FIELDKIT_DATA_DIR`/`FIELDKIT_LOG_DIR` env vars) rather than hardcoded per client — same pattern `_demo` follows. Full suite verified green in a clean worktree: **546 passed** (462 `platform/photo-agent` + 84 `platform/email-agent`), no regressions.

## Architectural decision made in this PR

`platform/docs/hermes/02-gateway-setup.md` flagged an open question for #11/#12: Hermes runs as a single gateway process with one global `config.yaml`/`.env`, so multiple demo clients on the same dev Mac Mini need *some* mechanism to get independently-configured providers. Two options existed: named gateway profiles vs. Hermes's `model_routes`/profile-routing block.

**Chose: named gateway profiles.** Confirmed with the human that production never runs multiple clients on one installation (each client gets its own install), so this only matters during the current interim dev period where `_demo` and `mercury` share a physical Mac Mini. Profiles match that problem directly (one profile per client, own config/secrets/bot token) and cost nothing in production, where an install only ever has one (default) profile anyway. Live-verified: `gateway install` under a named profile creates a genuinely separate launchd service, isolated from `_demo`'s default-profile gateway.

## Live-verification history (three codex review rounds)

**Round 1** caught that the originally-documented setup sequence didn't run as written. Live-verified against installed Hermes CLI v0.20.5 with throwaway test profiles (created, inspected, deleted each time) and corrected the secret path (`~/.hermes/profiles/<name>/.env`), the missing gateway config (`ANTHROPIC_API_KEY`, gateway `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USERS`, `skills.external_dirs`), and the missing `CLIENT_NAME` step.

**Round 2** caught my own mistake: I'd claimed no `-p`/`--profile` flag exists anywhere, reasoning from its absence in `--help` output. Wrong — `hermes -p <name> <command>` is real, undocumented, and scopes a single invocation without touching the sticky global default (`hermes profile use <name>`, a separate real mechanism). Reproduced independently (`config set`, `gateway install --no-start-now --no-start-on-login`, `gateway status`, `gateway uninstall`, `profile delete` — all correctly scoped, zero effect on `_demo`'s running gateway). Switched the checklist to `-p mercury` per-command (safer for a human pasting commands one at a time, no lingering sticky state) — matching the OpenAI-backed sibling client's setup (#12/PR #44). Also fixed `CLIENT_NAME` to an inline per-invocation override rather than a permanent root-`.env` edit, since `_demo`'s cron reads that file live on this Mac Mini.

**Round 3** caught that the checklist covered `run_e2e_test.py` Stages 1–3 but not Stages 4–5: since the shared root `CLIENT_NAME` correctly stays `_demo` (per round 2's fix), `_demo`'s cron jobs won't advance mercury's approval/publish stages — the e2e rig would hang waiting for a `check_approval.py`/`upload_facebook.py` run that never happens for mercury. Added manual, mercury-scoped invocations for both stages (checklist item 9 below) — same fix venus's PR #44 already needed for the same reason. Also fixed imprecise wording ("parametrized" → "environment-driven/client-agnostic") for how the shared test suites handle multiple clients.

## NOT done in this PR — deliberately deferred

The issue's third acceptance criterion — "one full cycle verified end-to-end: trigger → photo processing → Telegram approval → confirmed post" — is **not** attempted here. Sandeep wants to run that live verification himself, together with the orchestrator, after both #11 and #12 land. Everything needed to run it is scaffolded (client directory, `.env.example`, reuse of `platform/photo-agent/scripts/run_e2e_test.py` exactly as `_demo` uses it) — only live credentials are missing.

### Exact live-setup checklist for the deferred e2e run

1. **New Telegram bots (2, via BotFather)** — mercury needs its own `TELEGRAM_BOT_TOKEN` (used by *both* the Hermes gateway profile's `.env` and, separately, by `clients/mercury/src/photo-agent/.env` for Hermes's chat-driven commands) and `TELEGRAM_APPROVAL_BOT_TOKEN` (dedicated approval-buttons bot for `check_approval.py`'s cron leg — per issue #29, must differ from the gateway bot to avoid the `getUpdates` offset race). Send `/start` to the approval bot once so it can message the admin.
2. **`ADMIN_TELEGRAM_CHAT_ID`** (for `clients/mercury/src/photo-agent/.env`) and **`TELEGRAM_ALLOWED_USERS`** (for the Hermes profile's `.env`, admin's Telegram user id) — confirm which chat ID/user to use.
3. **Google Drive** — a new root folder for mercury's photo intake (`DRIVE_ROOT_FOLDER_ID`), separate from `_demo`'s and `_construction_co`'s. Drive OAuth credentials (`GOOGLE_USER_CREDENTIALS_FILE`) can reuse the existing `gws` setup if the same Google account is fine, or need a fresh `gws auth login` if not.
4. **Gmail account** — `AGENT_EMAIL` / `ADMIN_EMAIL` for the approval-email path, separate from `_demo`'s agent Gmail.
5. **Facebook Page connection** — `FB_APP_ID`/`FB_APP_SECRET` (Meta Developer App, can likely reuse `_demo`'s app registration) and a Facebook Page to post to; `FB_PAGE_ID`/`FB_PAGE_ACCESS_TOKEN` get written automatically by `generate_auth_link.py` once the above two are set.
6. **Anthropic API key confirmation** — confirm whether mercury's Hermes profile should use the same `ANTHROPIC_API_KEY` already in the default profile's `.env` (shared account) or a distinct key for cleaner cost attribution between `_demo` and `mercury`.
7. **Hermes profile setup (live, on the Mac Mini)** — not yet run, syntax live-verified against installed Hermes v0.20.5:
   ```bash
   hermes profile create mercury --no-alias
   hermes -p mercury config set model.provider anthropic
   hermes -p mercury config set model.default claude-sonnet-5
   hermes -p mercury config set skills.external_dirs '["~/src/fieldkit/platform/photo-agent/skills"]'
   # then edit ~/.hermes/profiles/mercury/.env directly:
   #   ANTHROPIC_API_KEY=...
   #   TELEGRAM_BOT_TOKEN=...        (mercury's gateway bot, from step 1)
   #   TELEGRAM_ALLOWED_USERS=...    (admin's Telegram user id)
   #   chmod 600 ~/.hermes/profiles/mercury/.env   # defense-in-depth; Hermes already creates it 0600
   hermes -p mercury gateway install --start-now --start-on-login
   hermes -p mercury doctor    # -> Anthropic API check should pass
   hermes -p mercury skills list --source local   # preflight: confirm both FieldKit skills (process-photos, check-approval) are discovered before starting a run
   ```
   `-p mercury` scopes each command to that profile only (verified: doesn't touch the global sticky default or `_demo`'s running gateway). This installs a separate launchd service (`ai.hermes.gateway-mercury.plist`).
8. **Repo-root `fieldkit/.env`** — do NOT permanently change `CLIENT_NAME` there (`_demo`'s cron reads it live). Prefix each mercury script/e2e invocation instead: `CLIENT_NAME=mercury FIELDKIT_ROOT=<absolute path> python3 platform/photo-agent/scripts/run_e2e_test.py --duration 20`.
9. **Stages 4–5 need manual, mercury-scoped invocations too.** `run_e2e_test.py` polls for `check_approval.py`/`upload_facebook.py` to advance the run, but those are normally driven by `_demo`'s cron (`CLIENT_NAME=_demo`), which will never see mercury's pending job. While the e2e rig is waiting at each stage, run in another terminal:
   ```bash
   # During Stage 4 (approval) — repeat/poll until Telegram approval is processed:
   CLIENT_NAME=mercury FIELDKIT_ROOT=/absolute/path/to/fieldkit \
     python3 platform/photo-agent/scripts/check_approval.py --source cron

   # During Stage 5 (Facebook publish) — once approved:
   CLIENT_NAME=mercury FIELDKIT_ROOT=/absolute/path/to/fieldkit \
     python3 platform/photo-agent/scripts/upload_facebook.py --source cron
   ```
   (Same gap venus's PR #44 hit and fixed for the OpenAI-backed client, for the same reason.)
10. **`clients/mercury/data/` and `clients/mercury/logs/`** — create these directories (or let the first run create them) and point `FIELDKIT_DATA_DIR`/`FIELDKIT_LOG_DIR` at them in mercury's `.env`.

None of the e2e acceptance box is marked done here — that's intentional.

## Test plan

- [x] `clients/mercury/` scaffolded matching `_template`'s convention
- [x] Model config (constitution.md + `.env.example`) explicitly documents Anthropic, not assumed
- [x] Hermes setup syntax live-verified across three review rounds against installed Hermes CLI v0.20.5 (not just docs)
- [x] Full existing test suite green: 546 passed (`platform/photo-agent` 462, `platform/email-agent` 84), no regressions
- [ ] Live e2e photo-approval cycle — deliberately deferred, see checklist above