### PR TITLE
Document Facebook Page ID / token-type pitfalls from mercury onboarding

### DIFF
--- a/platform/photo-agent/SKILL_generate_auth_link.md
+++ b/platform/photo-agent/SKILL_generate_auth_link.md
@@ -95,5 +95,5 @@ Use the [Token Debugger](https://developers.facebook.com/tools/debug/accesstoken
 |---|---|
 | "Invalid Scopes" in browser | App use case is wrong — see [01-create-app.md](docs/facebook/01-create-app.md) Step 2 |
 | Port already in use | Run with `--port 8081`; add `http://localhost:8081/callback` to redirect URIs |
-| "Page not found" (exit 3) | Verify the Page ID and that the authorizing account is a Page admin |
+| "Page not found" (exit 3) | Verify the Page ID and that the authorizing account is a Page admin — don't use the ID from the Page's own URL (`profile.php?id=...`), which can be a different identifier for Pages on Meta's newer unified Page UI; get the real ID from `GET /me/accounts` instead (see [02-manual-test.md, Part B](docs/facebook/02-manual-test.md)) |
 | Token expired later | Re-run this script — it always produces a non-expiring Page token |

--- a/platform/photo-agent/docs/facebook/01-create-app.md
+++ b/platform/photo-agent/docs/facebook/01-create-app.md
@@ -171,9 +171,23 @@ The account that runs the OAuth flow must be an admin of the target Page.
 
 **Finding your Page ID** — you will need it for `--page-id`:
 
-- Option 1: On the Page, click **About** in the left menu. Look for **Page ID** — it is a long number (e.g. `123456789012345`).
-- Option 2: Use Graph API Explorer (covered in doc 2) — `GET /me/accounts` returns the ID alongside the token.
-- Option 3: The Page URL sometimes contains the ID directly: `facebook.com/profile.php?id=123456789012345`.
+> **Do not copy the number from the Page's own URL and use it as `FB_PAGE_ID`.**
+> For Pages created under Meta's newer unified "Page" UI, the Page's URL looks
+> like `facebook.com/profile.php?id=NNNNN` — but that number can be a
+> **completely different identifier** from the Page's actual Graph API node ID.
+> Using it as `FB_PAGE_ID` produces confusing failures later (a real example:
+> a Page's URL showed `61593898195789`, but its real Graph API Page ID —
+> confirmed via `/me/accounts` and cross-checked with the Token Debugger — was
+> `1187029124503799`). See [doc 2, Troubleshooting](02-manual-test.md) for the
+> failure this causes.
+
+- **Recommended** — Use Graph API Explorer (covered in [doc 2, Part B](02-manual-test.md)):
+  call `GET /me/accounts`, find the entry whose **`name`** matches your Page, and
+  use *that entry's* `id` field. This is the only source guaranteed to match what
+  the rest of the Graph API (and `generate_auth_link.py`) expects.
+- On the Page, click **About** in the left menu and look for **Page ID**. This
+  usually matches the Graph API ID, but if it disagrees with what `/me/accounts`
+  returns, trust `/me/accounts`.
 
 ---
 

--- a/platform/photo-agent/docs/facebook/02-manual-test.md
+++ b/platform/photo-agent/docs/facebook/02-manual-test.md
@@ -20,22 +20,28 @@ a real token, without writing any code.
 
 2. In the top-right dropdown labelled **Meta App**, select your app (e.g. **FieldKit Demo**).
 
-3. Click **Generate Access Token**.
+3. Next to it, find the **"User or Page"** token-type dropdown and explicitly set it
+   to **User Token**. It defaults to whatever was last selected in your browser —
+   which may be **Page Token** left over from a previous session — and the Explorer
+   does not warn you if it's wrong. Generating a Page token here by mistake produces
+   a confusing failure later (see [Troubleshooting](#troubleshooting) below).
 
-4. A permissions dialog appears. Before clicking anything, expand the **permissions** panel on the right side of the Explorer and add:
+4. Click **Generate Access Token**.
+
+5. A permissions dialog appears. Before clicking anything, expand the **permissions** panel on the right side of the Explorer and add:
    - `pages_show_list`
    - `pages_read_engagement`
    - `pages_manage_posts`
 
    Then click **Generate Access Token** again (or the dialog may already be open — check it includes those scopes).
 
-5. Facebook shows a login/permissions screen. Click **Continue as [your name]**, then **Save**.
+6. Facebook shows a login/permissions screen. Click **Continue as [your name]**, then **Save**.
 
    > If you see "Invalid Scopes" or any permission is greyed out, your app's use case
    > is not configured correctly. Return to [doc 1, Step 5](01-create-app.md) and
    > verify the permissions are added.
 
-6. The Explorer shows a token in the **Access Token** field. This is a **short-lived user access token** (valid ~1 hour). Copy it.
+7. The Explorer shows a token in the **Access Token** field. This is a **short-lived user access token** (valid ~1 hour). Copy it.
 
 ---
 
@@ -65,6 +71,12 @@ The response should look like:
 }
 ```
 
+> **If your account admins more than one Page**, `data` will have multiple entries.
+> Match the entry by its **`name`** field — not by any Page ID you already have
+> from the browser or the Page's URL, which can be a completely different
+> identifier (see [doc 1, Part E](01-create-app.md)). Use *that entry's* `id`
+> field as your `FB_PAGE_ID`.
+
 - **`id`** is your `FB_PAGE_ID`. Copy it.
 - **`access_token`** in the response is a **Page access token**. Copy it.
 - The `tasks` list must contain **`CREATE_CONTENT`** — this is what allows posting.
@@ -72,6 +84,12 @@ The response should look like:
 > If the `data` array is empty, the Facebook account you authorised with is not
 > an admin of any Page. Make sure you are logged in as the Page admin and re-run
 > the Explorer flow from Part A.
+>
+> If you instead get an error like `"Tried accessing nonexisting field (accounts)"`,
+> the token in the Explorer's Access Token field is a **Page** token, not a **User**
+> token — Page nodes have no `/accounts` edge. Go back to Part A and confirm the
+> token-type dropdown was set to **User Token**. See
+> [Troubleshooting](#troubleshooting) for how to positively identify a token's type.
 
 ---
 
@@ -145,8 +163,19 @@ The `expires_in` is ~60 days. Save this long-lived user token.
 
 ```bash
 curl -s "https://graph.facebook.com/v25.0/me/accounts
-  ?access_token=LONG_LIVED_USER_TOKEN"
+  ?access_token=LONG_LIVED_USER_TOKEN" | python3 -m json.tool
 ```
+
+Piping through `python3 -m json.tool` pretty-prints the response — worth doing any
+time your account admins more than one Page, so you can visually match each
+`name` to its `id` instead of picking through one unbroken line of JSON. As in
+Part B, if more than one Page comes back, match by **`name`** — don't assume the
+first entry, and don't substitute a Page ID you already have from the browser.
+
+> Current Meta docs favor the explicit form `GET /{user-id}/accounts` over the
+> `/me/accounts` alias used above. They are functionally equivalent today, but
+> the explicit form is the more future-proof one to reach for. Get your user ID
+> first with `GET /me?access_token=LONG_LIVED_USER_TOKEN`, then substitute it in.
 
 The `access_token` values in the response's `data` array are now **long-lived Page access tokens that do not expire** (they are only invalidated if the user changes their password, deauthorises the app, or the Page admin role is removed).
 
@@ -204,5 +233,6 @@ python3 scripts/generate_auth_link.py --page-id YOUR_PAGE_ID
 | Token expires in 1 hour | Short-lived user token used to call `/accounts` | Do Part D to exchange for a permanent Page token |
 | "This app is in development mode" error | The account has no role on the app | Add the account as Tester under App Roles → Roles in the app dashboard |
 | "App not active" when opening the OAuth URL | The Meta app may need a Business Manager connection, or the app is in a state that blocks the OAuth dialog | Use the manual token flow in this doc (Parts A–D) instead of `generate_auth_link.py`. Both produce the same long-lived Page token. |
-| `FacebookUploadError: global id X is not allowed` | Wrong Page ID in `.env` | Confirm the Page ID from the `id` field in `GET /me/accounts` response — not the URL or profile ID |
+| `(#100) Tried accessing nonexisting field (accounts)` calling `/me/accounts` or `fb_exchange_token` | You passed a **Page** access token where a **User** token was expected — Page nodes have no `/accounts` edge | Confirm the token type before retrying blind: `curl -s "https://graph.facebook.com/v25.0/debug_token?input_token=TOKEN&access_token=APP_ID\|APP_SECRET"`. `"type":"PAGE"` (with a `profile_id`) means it's a Page token; `"type":"USER"` (with a `user_id`, no `profile_id`) means it's a User token. Go back to Part A and regenerate with the token-type dropdown set to **User Token**. |
+| `FacebookUploadError: global id X is not allowed` | Wrong Page ID in `.env` | Confirm the Page ID from the `id` field in `GET /me/accounts` response — not the URL or profile ID. For Pages using Meta's newer unified Page UI, the `profile.php?id=...` number in the URL is a **different ID** from the real Graph API Page ID — match by the Page's `name` in the `/me/accounts` response instead (see [doc 1, Part E](01-create-app.md)). |
 | `FacebookUploadError: Application has been deleted` (code 101) | Wrong `FB_APP_ID` or `FB_APP_SECRET` in `.env` | Copy the exact values from App Settings → Basic in the developer console |

--- a/platform/photo-agent/docs/facebook/02-manual-test.md
+++ b/platform/photo-agent/docs/facebook/02-manual-test.md
@@ -76,6 +76,11 @@ The response should look like:
 > from the browser or the Page's URL, which can be a completely different
 > identifier (see [doc 1, Part E](01-create-app.md)). Use *that entry's* `id`
 > field as your `FB_PAGE_ID`.
+>
+> If two Pages share the exact same name, name-matching alone won't disambiguate
+> them — open the Page you actually want in a browser tab and cross-check via
+> **About → Page ID**, or paste each candidate's `access_token` into the Token
+> Debugger and compare its `profile_id` against the `id` you're trying to confirm.
 
 - **`id`** is your `FB_PAGE_ID`. Copy it.
 - **`access_token`** in the response is a **Page access token**. Copy it.
@@ -233,6 +238,36 @@ python3 scripts/generate_auth_link.py --page-id YOUR_PAGE_ID
 | Token expires in 1 hour | Short-lived user token used to call `/accounts` | Do Part D to exchange for a permanent Page token |
 | "This app is in development mode" error | The account has no role on the app | Add the account as Tester under App Roles → Roles in the app dashboard |
 | "App not active" when opening the OAuth URL | The Meta app may need a Business Manager connection, or the app is in a state that blocks the OAuth dialog | Use the manual token flow in this doc (Parts A–D) instead of `generate_auth_link.py`. Both produce the same long-lived Page token. |
-| `(#100) Tried accessing nonexisting field (accounts)` calling `/me/accounts` or `fb_exchange_token` | You passed a **Page** access token where a **User** token was expected — Page nodes have no `/accounts` edge | Confirm the token type before retrying blind: `curl -s "https://graph.facebook.com/v25.0/debug_token?input_token=TOKEN&access_token=APP_ID\|APP_SECRET"`. `"type":"PAGE"` (with a `profile_id`) means it's a Page token; `"type":"USER"` (with a `user_id`, no `profile_id`) means it's a User token. Go back to Part A and regenerate with the token-type dropdown set to **User Token**. |
-| `FacebookUploadError: global id X is not allowed` | Wrong Page ID in `.env` | Confirm the Page ID from the `id` field in `GET /me/accounts` response — not the URL or profile ID. For Pages using Meta's newer unified Page UI, the `profile.php?id=...` number in the URL is a **different ID** from the real Graph API Page ID — match by the Page's `name` in the `/me/accounts` response instead (see [doc 1, Part E](01-create-app.md)). |
+| `(#100) Tried accessing nonexisting field (accounts)` calling `/me/accounts` or `fb_exchange_token` | You passed a **Page** access token where a **User** token was expected — Page nodes have no `/accounts` edge | Confirm the token type before retrying blind, via the [Token Debugger UI](https://developers.facebook.com/tools/debug/accesstoken/) (same tool as Part E) — paste the token, no app secret needed. `"type":"PAGE"` (with a `profile_id`) means it's a Page token; `"type":"USER"` (with a `user_id`, no `profile_id`) means it's a User token. Go back to Part A and regenerate with the token-type dropdown set to **User Token**. (A curl form of this check exists but needs your app secret — see [below](#checking-a-tokens-type-without-exposing-your-app-secret) before using it.) |
+| `FacebookUploadError: global id X is not allowed` | Wrong Page ID in `.env` | Confirm the Page ID from the `id` field in `GET /me/accounts` response — not the URL or profile ID. For Pages using Meta's newer unified Page UI, the `profile.php?id=...` number in the URL is a **different ID** from the real Graph API Page ID (a real example: URL showed `61593898195789`, actual Graph API Page ID was `1187029124503799`) — match by the Page's `name` in the `/me/accounts` response instead (see [doc 1, Part E](01-create-app.md)). |
 | `FacebookUploadError: Application has been deleted` (code 101) | Wrong `FB_APP_ID` or `FB_APP_SECRET` in `.env` | Copy the exact values from App Settings → Basic in the developer console |
+
+### Checking a token's type without exposing your app secret
+
+The `debug_token` endpoint's curl form needs an app access token
+(`APP_ID|APP_SECRET`) to authorize the lookup. Don't type the secret directly
+into a curl URL — the same rule [doc 1](01-create-app.md) states for
+`FB_APP_SECRET` ("must never be committed to git, logged, or appear anywhere
+in the cron path") applies here too: a secret embedded in a command's
+arguments is visible to any other process on the machine via `ps` for as long
+as curl is running, and separately risks being written to your shell history.
+
+**Prefer the Token Debugger UI** linked above for this check — paste in the
+token you're unsure about and click **Debug**. It needs no app secret at all
+for this specific lookup.
+
+**If you must script it**, keep the secret out of your typed command text
+(so it isn't saved verbatim into shell history) by reading it interactively
+instead of writing it inline:
+```bash
+read -rs -p "App secret: " FB_APP_SECRET; echo
+curl -sS "https://graph.facebook.com/v25.0/debug_token?input_token=TOKEN&access_token=${FB_APP_ID}|${FB_APP_SECRET}"
+```
+This keeps the literal secret out of your shell history. It does **not** hide
+it from `ps` — once the shell expands the variables, curl's full argument
+list (secret included) is still visible to other users on the machine for
+the life of the request. For a one-off manual check, use the UI instead.
+
+Either way, don't paste the full `debug_token` response into tickets, logs,
+or chat — it includes scopes, expiry, and internal IDs beyond what's needed
+to answer the type question.


### PR DESCRIPTION
## Summary
- Fast-follow docs fix from live findings while connecting mercury's Facebook Page — no linked issue, same pattern as prior docs-only PRs this session.
- `02-manual-test.md`: call out the Graph API Explorer's "User or Page" token-type dropdown explicitly (Part A), add Page name-matching guidance for multi-Page accounts (Parts B & D), recommend pretty-printing `/me/accounts` with `python3 -m json.tool`, note the `/{user-id}/accounts` alternative, and add/extend Troubleshooting rows for the Page-vs-User token mixup (`(#100) Tried accessing nonexisting field (accounts)`, fixed via the Token Debugger's `debug_token` endpoint) and the Page-ID mismatch.
- `01-create-app.md`: correct Part E's "Finding your Page ID" guidance — it previously suggested reading the ID straight from the Page's `profile.php?id=...` URL, which was the actual root cause of today's confusion (a real Page's URL ID and its Graph API node ID were completely different numbers).
- `SKILL_generate_auth_link.md`: point its "Page not found" (exit 3) troubleshooting row at the same fix.
- Checked `clients/mercury/README.md` and `clients/venus/README.md` — neither duplicates this Facebook setup content, so no changes needed there.

## Test plan
- [x] `platform/photo-agent` test suite: 470 passed
- [x] `platform/email-agent` test suite: 84 passed
- [x] No doc-content regression tests exist for these files (checked the `test_check_email_skill.py`-style pattern — those only cover Hermes-dispatched `SKILL.md` files, not these prose walkthrough docs), so none were added.
- [x] Manually re-read all edited sections in place to confirm they fit the existing Parts A–E / Troubleshooting-table structure without restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)