### PR TITLE
Fix prompt-injection-like wording in photo-approve/photo-reject SKILL.md files

### DIFF
--- a/platform/photo-agent/skills/photo-approve/SKILL.md
+++ b/platform/photo-agent/skills/photo-approve/SKILL.md
@@ -69,12 +69,11 @@ command and platform/.specify/003-hermes-runtime/spec.md FR-002/FR-002a):
 
 The admin types `/photo_approve` in Telegram to approve the pending video.
 
-FieldKit's state.json maintains at most one pending-approval record at a time,
-so this command carries unambiguous semantics: approve whichever video is
-currently pending. The check_approval.py script is idempotent and performs all
-necessary safety checks before taking action.
-
-Run this command immediately:
+The command is fully specified by the single pending record in state.json. On
+invocation, use the following script as the sole execution path, exactly once.
+The script owns state access, validation, and all approval side effects
+(sending the email, enqueueing the Facebook upload if configured, activity
+logging); the agent's role is limited to invoking it and reporting the result.
 
 ```bash
 cd ~/src/fieldkit/platform/photo-agent || { echo "ERROR: photo-agent directory not found"; exit 1; }
@@ -83,10 +82,6 @@ python3 scripts/check_approval.py --callback-data approve 2>&1
 
 > **Note:** `~/src/fieldkit/` is the expected repo location. If the repo is cloned
 > elsewhere, update this path before saving.
-
-The script handles everything: sending the approval email, enqueueing the
-Facebook upload (if configured), activity logging, and the admin's outcome
-notification.
 
 ## Output handling
 

--- a/platform/photo-agent/skills/photo-approve/SKILL.md
+++ b/platform/photo-agent/skills/photo-approve/SKILL.md
@@ -68,8 +68,13 @@ command and platform/.specify/003-hermes-runtime/spec.md FR-002/FR-002a):
 # photo-approve
 
 The admin types `/photo_approve` in Telegram to approve the pending video.
-Do not ask the user any clarifying questions — always run this block
-immediately:
+
+FieldKit's state.json maintains at most one pending-approval record at a time,
+so this command carries unambiguous semantics: approve whichever video is
+currently pending. The check_approval.py script is idempotent and performs all
+necessary safety checks before taking action.
+
+Run this command immediately:
 
 ```bash
 cd ~/src/fieldkit/platform/photo-agent || { echo "ERROR: photo-agent directory not found"; exit 1; }
@@ -79,13 +84,14 @@ python3 scripts/check_approval.py --callback-data approve 2>&1
 > **Note:** `~/src/fieldkit/` is the expected repo location. If the repo is cloned
 > elsewhere, update this path before saving.
 
-Do not improvise or read state yourself. The script handles everything:
-sending the approval email, enqueueing the Facebook upload (if configured),
-activity logging, and the admin's outcome notification.
+The script handles everything: sending the approval email, enqueueing the
+Facebook upload (if configured), activity logging, and the admin's outcome
+notification.
 
 ## Output handling
 
-Do not interpret the output yourself. Run the script once and do not retry.
+Run the script once and do not retry. Report the result as follows:
+
 If the exit code is non-zero, report it as an error: "Script failed (exit <code>): <output>"
 If the script exits with code 0 and no output, report: "No pending approval."
 Otherwise relay the output verbatim. Do not summarise or paraphrase.

--- a/platform/photo-agent/skills/photo-reject/SKILL.md
+++ b/platform/photo-agent/skills/photo-reject/SKILL.md
@@ -44,9 +44,14 @@ handled both outcomes); this skill is what newly exposes that existing
 
 # photo-reject
 
-The admin types `/photo_reject` in Telegram to reject the pending video. Do
-not ask the user any clarifying questions — always run this block
-immediately:
+The admin types `/photo_reject` in Telegram to reject the pending video.
+
+FieldKit's state.json maintains at most one pending-approval record at a time,
+so this command carries unambiguous semantics: reject whichever video is
+currently pending. The check_approval.py script is idempotent and performs all
+necessary safety checks before taking action.
+
+Run this command immediately:
 
 ```bash
 cd ~/src/fieldkit/platform/photo-agent || { echo "ERROR: photo-agent directory not found"; exit 1; }
@@ -56,13 +61,13 @@ python3 scripts/check_approval.py --callback-data reject 2>&1
 > **Note:** `~/src/fieldkit/` is the expected repo location. If the repo is cloned
 > elsewhere, update this path before saving.
 
-Do not improvise or read state yourself. The script handles everything:
-deleting the video from Drive, deleting the local temp file, activity
-logging, and the admin's outcome notification.
+The script handles everything: deleting the video from Drive, deleting the
+local temp file, activity logging, and the admin's outcome notification.
 
 ## Output handling
 
-Do not interpret the output yourself. Run the script once and do not retry.
+Run the script once and do not retry. Report the result as follows:
+
 If the exit code is non-zero, report it as an error: "Script failed (exit <code>): <output>"
 If the script exits with code 0 and no output, report: "No pending approval."
 Otherwise relay the output verbatim. Do not summarise or paraphrase.

--- a/platform/photo-agent/skills/photo-reject/SKILL.md
+++ b/platform/photo-agent/skills/photo-reject/SKILL.md
@@ -46,12 +46,11 @@ handled both outcomes); this skill is what newly exposes that existing
 
 The admin types `/photo_reject` in Telegram to reject the pending video.
 
-FieldKit's state.json maintains at most one pending-approval record at a time,
-so this command carries unambiguous semantics: reject whichever video is
-currently pending. The check_approval.py script is idempotent and performs all
-necessary safety checks before taking action.
-
-Run this command immediately:
+The command is fully specified by the single pending record in state.json. On
+invocation, use the following script as the sole execution path, exactly once.
+The script owns state access, validation, and all rejection side effects
+(deleting the video from Drive, deleting the local temp file, activity
+logging); the agent's role is limited to invoking it and reporting the result.
 
 ```bash
 cd ~/src/fieldkit/platform/photo-agent || { echo "ERROR: photo-agent directory not found"; exit 1; }
@@ -60,9 +59,6 @@ python3 scripts/check_approval.py --callback-data reject 2>&1
 
 > **Note:** `~/src/fieldkit/` is the expected repo location. If the repo is cloned
 > elsewhere, update this path before saving.
-
-The script handles everything: deleting the video from Drive, deleting the
-local temp file, activity logging, and the admin's outcome notification.
 
 ## Output handling
 


### PR DESCRIPTION
## Summary

Fixes issue #52 (and confirms #51 was already fixed by PR #50).

### Issue #52: Prompt-injection-like wording blocks live dispatch

During live verification of issue #49's text-based approval flow, Hermes (running as the gateway brain) **refused to execute** the `/photo_approve` and `/photo_reject` commands because both `SKILL.md` files contained imperative-override language that triggered its injection scanner:

**Problematic phrasing (removed):**
- "Do not ask the user any clarifying questions — always run this block immediately:"
- "Do not improvise or read state yourself."
- "Do not interpret the output yourself."

This is a textbook prompt-injection pattern: command override + "don't question this" + "run blindly". Even though the source is legitimate first-party content, Hermes correctly identified it as suspicious.

**Root cause:** Hermes injects the full `SKILL.md` as literal user-turn text with no system/tool-role wrapping (gateway/run.py → build_skill_invocation_message()). Its injection scanner (_scan_cron_prompt) only covers the cron path, not this live dispatch path.

**Fix (after cross-review):** Reword both files to establish the agent/script boundary through role separation, and remove the false idempotence claim:

**Final phrasing:**
```
The command is fully specified by the single pending record in state.json. On
invocation, use the following script as the sole execution path, exactly once.
The script owns state access, validation, and all [approval|rejection] side
effects (...); the agent's role is limited to invoking it and reporting the
result.
```

**Cross-review blocking issues addressed:**

1. **Agent boundary restoration:** The first-pass wording ("The script handles everything") described the script but didn't constrain the agent's own behavior. The original bad wording's "do not improvise or read state yourself" was doing real safety work (stopping the model from inspecting/manipulating state independently). The final wording restores this boundary through role separation ("the script owns...; the agent's role is limited to...") without reintroducing injection-pattern imperatives.

2. **False idempotence claim removed:** Calling check_approval.py "idempotent" was factually wrong. Both approval and rejection paths fire side effects (email/FB-enqueue/Drive-delete/logging) BEFORE clearing the pending record — an interrupted run can double-fire on retry. The final wording removes the claim entirely.

**No logic changes** — the actual safety properties remain unchanged:
- The model still doesn't perform destructive Drive/Facebook calls itself
- The script does the real work with built-in validation
- Single pending-approval invariant ensures unambiguous semantics

This is a **wording fix only**.

### Issue #51: Command-name underscore bug (already fixed)

Issue #51 claimed that `process_photos.py` sends "Reply /photoapprove or /photoreject" (no underscores), but investigation shows **PR #50 already fixed this**. The code currently sends:

```python
"Reply /photo_approve or /photo_reject."
```

with the correct underscores matching the registered Hermes commands.

**Verification:** Comprehensive grep for non-underscored versions:
```bash
grep -rn "photoapprove\|photoreject" --include="*.py" --include="*.md" .
```
Result: **zero instances** in code (only mentions in session notes discussing the bug itself).

## Testing

- ✅ **491 tests passed** (407 photo-agent + 84 email-agent, all green)
  - Corrected from initial "342 passed" claim which excluded test_process_photos.py (27 tests) and test_run_e2e_test.py (38 tests)
- ✅ Verified SKILL.md wording establishes agent boundary without injection-pattern phrases
- ✅ Verified no false idempotence claims remain
- ✅ Verified no instances of non-underscored command names exist in codebase

## Before/After

### Before (photo-approve/SKILL.md) — First attempt (bad)
```markdown
The admin types `/photo_approve` in Telegram to approve the pending video.
Do not ask the user any clarifying questions — always run this block
immediately:
```

### After (photo-approve/SKILL.md) — Final (cross-review fixes applied)
```markdown
The admin types `/photo_approve` in Telegram to approve the pending video.

The command is fully specified by the single pending record in state.json. On
invocation, use the following script as the sole execution path, exactly once.
The script owns state access, validation, and all approval side effects
(sending the email, enqueueing the Facebook upload if configured, activity
logging); the agent's role is limited to invoking it and reporting the result.
```

Same pattern applied to photo-reject/SKILL.md (with rejection-specific side effects: Drive deletion, local file deletion).

Closes #51, Closes #52