### PR TITLE
Resolve relative VIDEO_TMP_DIR against FIELDKIT_DATA_DIR, not repo root

### DIFF
--- a/clients/_construction_co/src/photo-agent/.env.example
+++ b/clients/_construction_co/src/photo-agent/.env.example
@@ -48,7 +48,9 @@ DRIVE_ROOT_FOLDER_ID=   # required — separate Drive folder
 # ---------------------------------------------------------------------------
 
 SECONDS_PER_PHOTO=4
-VIDEO_TMP_DIR=data/photo-agent/tmp
+# Leave unset (commented out) to default to <FIELDKIT_DATA_DIR>/photo-agent/tmp,
+# which keeps each client's tmp files isolated from other clients.
+#VIDEO_TMP_DIR=data/photo-agent/tmp
 
 # ---------------------------------------------------------------------------
 # Facebook — NOT used by _construction_co

--- a/clients/_demo/src/photo-agent/.env.example
+++ b/clients/_demo/src/photo-agent/.env.example
@@ -29,8 +29,10 @@ DRIVE_ROOT_FOLDER_ID=  # required
 # Display duration per photo in seconds (default: 4)
 SECONDS_PER_PHOTO=4
 
-# Local temp directory for downloaded photos and the generated video
-VIDEO_TMP_DIR=data/photo-agent/tmp
+# Local temp directory for downloaded photos and the generated video.
+# Leave unset (commented out) to default to <FIELDKIT_DATA_DIR>/photo-agent/tmp,
+# which keeps each client's tmp files isolated from other clients.
+#VIDEO_TMP_DIR=data/photo-agent/tmp
 
 # Path to Drive OAuth credentials JSON (ADC format — client_id, client_secret, refresh_token).
 # Default: ~/.config/gws/user_credentials.json

--- a/clients/mercury/src/photo-agent/.env.example
+++ b/clients/mercury/src/photo-agent/.env.example
@@ -79,8 +79,10 @@ DRIVE_ROOT_FOLDER_ID=  # required
 # Display duration per photo in seconds (default: 4)
 SECONDS_PER_PHOTO=4
 
-# Local temp directory for downloaded photos and the generated video
-VIDEO_TMP_DIR=data/photo-agent/tmp
+# Local temp directory for downloaded photos and the generated video.
+# Leave unset (commented out) to default to <FIELDKIT_DATA_DIR>/photo-agent/tmp,
+# which keeps each client's tmp files isolated from other clients.
+#VIDEO_TMP_DIR=data/photo-agent/tmp
 
 # Path to Drive OAuth credentials JSON (ADC format — client_id, client_secret, refresh_token).
 # Default: ~/.config/gws/user_credentials.json

--- a/clients/venus/src/photo-agent/.env.example
+++ b/clients/venus/src/photo-agent/.env.example
@@ -36,8 +36,10 @@ DRIVE_ROOT_FOLDER_ID=  # required
 # Display duration per photo in seconds (default: 4)
 SECONDS_PER_PHOTO=4
 
-# Local temp directory for downloaded photos and the generated video
-VIDEO_TMP_DIR=data/photo-agent/tmp
+# Local temp directory for downloaded photos and the generated video.
+# Leave unset (commented out) to default to <FIELDKIT_DATA_DIR>/photo-agent/tmp,
+# which keeps each client's tmp files isolated from other clients.
+#VIDEO_TMP_DIR=data/photo-agent/tmp
 
 # Path to Drive OAuth credentials JSON (ADC format — client_id, client_secret, refresh_token).
 # Default: ~/.config/gws/user_credentials.json — use a venus-specific path if

--- a/platform/photo-agent/.env.example
+++ b/platform/photo-agent/.env.example
@@ -71,9 +71,11 @@ DRIVE_ROOT_FOLDER_ID=  # required
 # Display duration per photo in seconds (default: 4)
 SECONDS_PER_PHOTO=4
 
-# Local temp directory for downloaded photos and the generated video
-# Relative paths are resolved against FIELDKIT_ROOT.
-VIDEO_TMP_DIR=data/photo-agent/tmp
+# Local temp directory for downloaded photos and the generated video.
+# Leave unset (commented out) to default to <FIELDKIT_DATA_DIR>/photo-agent/tmp,
+# which keeps each client's tmp files isolated from other clients. If set,
+# relative paths are resolved against FIELDKIT_DATA_DIR (not FIELDKIT_ROOT).
+#VIDEO_TMP_DIR=data/photo-agent/tmp
 
 # ---------------------------------------------------------------------------
 # Facebook Page connection (optional — skip if this client does not post to Facebook)

--- a/platform/photo-agent/scripts/check_approval.py
+++ b/platform/photo-agent/scripts/check_approval.py
@@ -73,14 +73,13 @@ load_dotenv(_ROOT / "clients" / _CLIENT / "src" / "photo-agent" / ".env", overri
 
 sys.path.insert(0, str(Path(__file__).parents[1]))
 
-from tools import drive, state
+from tools import drive, paths, state
 from tools import facebook_state
 from tools import logger as activity_log
 from tools import telegram_api
 
 _log = logging.getLogger(__name__)
 _PHOTO_AGENT_DIR = Path(__file__).parents[1]
-_REPO_ROOT = Path(__file__).parents[3]
 
 
 def _try_acquire_check_lock() -> "IO | None":
@@ -156,21 +155,11 @@ def _send_approval_email(agent_email: str, admin_email: str, project_name: str, 
     _log.info("approval email sent: project=%s", project_name)
 
 
-def _get_tmp_root() -> Path:
-    """Return the allowed root directory for local video files."""
-    tmp_raw = os.environ.get("VIDEO_TMP_DIR", "")
-    if tmp_raw:
-        p = Path(tmp_raw)
-        return (p if p.is_absolute() else (_REPO_ROOT / p)).resolve()
-    # Default to client-specific data dir so clients never share a tmp directory.
-    return (Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent" / "tmp").resolve()
-
-
 def _delete_local_file(video_local_path: str, project_name: str) -> None:
     """Delete the local temp video file, refusing to act on paths outside the tmp directory."""
     try:
         p = Path(video_local_path).resolve()
-        allowed = _get_tmp_root()
+        allowed = paths.get_video_tmp_root()
         try:
             p.relative_to(allowed)
         except ValueError:

--- a/platform/photo-agent/scripts/process_photos.py
+++ b/platform/photo-agent/scripts/process_photos.py
@@ -47,7 +47,6 @@ from tools.video_generator import FFmpegVideoGenerator, VideoConfig, VideoGenera
 
 _log = logging.getLogger(__name__)
 
-_REPO_ROOT = Path(__file__).parents[3]
 _PHOTO_AGENT_DIR = Path(__file__).parents[1]
 
 _MIN_PHOTOS = 2
@@ -150,7 +149,11 @@ def main(argv=None) -> None:
     tmp_base_raw = os.environ.get("VIDEO_TMP_DIR", "")
     if tmp_base_raw:
         p = Path(tmp_base_raw)
-        tmp_base = p if p.is_absolute() else (_REPO_ROOT / p).resolve()
+        # A relative VIDEO_TMP_DIR resolves against FIELDKIT_DATA_DIR (the
+        # per-client dir), not _REPO_ROOT (the shared fieldkit checkout) —
+        # otherwise every client whose .env ships the same relative default
+        # collides on one shared tmp directory (issue #47).
+        tmp_base = p if p.is_absolute() else (Path(os.environ["FIELDKIT_DATA_DIR"]) / p).resolve()
     else:
         # Default to the client-specific data dir so clients never share a tmp directory.
         tmp_base = Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent" / "tmp"

--- a/platform/photo-agent/scripts/process_photos.py
+++ b/platform/photo-agent/scripts/process_photos.py
@@ -39,7 +39,7 @@ load_dotenv(_ROOT / "clients" / _CLIENT / "src" / "photo-agent" / ".env", overri
 
 sys.path.insert(0, str(Path(__file__).parents[1]))
 
-from tools import drive, state
+from tools import drive, paths, state
 from tools import logger as activity_log
 from tools import telegram_api
 from tools.drive import DriveFolderNotFoundError
@@ -146,17 +146,7 @@ def main(argv=None) -> None:
             f"{os.environ.get('SECONDS_PER_PHOTO')!r}"
         )
 
-    tmp_base_raw = os.environ.get("VIDEO_TMP_DIR", "")
-    if tmp_base_raw:
-        p = Path(tmp_base_raw)
-        # A relative VIDEO_TMP_DIR resolves against FIELDKIT_DATA_DIR (the
-        # per-client dir), not _REPO_ROOT (the shared fieldkit checkout) —
-        # otherwise every client whose .env ships the same relative default
-        # collides on one shared tmp directory (issue #47).
-        tmp_base = p if p.is_absolute() else (Path(os.environ["FIELDKIT_DATA_DIR"]) / p).resolve()
-    else:
-        # Default to the client-specific data dir so clients never share a tmp directory.
-        tmp_base = Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent" / "tmp"
+    tmp_base = paths.get_video_tmp_root()
 
     try:
         lock_f = _acquire_run_lock()

--- a/platform/photo-agent/scripts/upload_facebook.py
+++ b/platform/photo-agent/scripts/upload_facebook.py
@@ -65,7 +65,7 @@ load_dotenv(_ROOT / "clients" / _CLIENT / "src" / "photo-agent" / ".env", overri
 
 sys.path.insert(0, str(Path(__file__).parents[1]))
 
-from tools import facebook_api, facebook_logger, facebook_state, telegram_api
+from tools import facebook_api, facebook_logger, facebook_state, paths, telegram_api
 from tools.facebook_api import FacebookTokenError, FacebookUploadError
 
 _log = logging.getLogger(__name__)
@@ -79,7 +79,6 @@ _COOLDOWN_SECONDS = 60
 # running would let a second cron tick reclaim and re-call the Facebook API for the same job.
 # See claim_pending_upload()'s docstring for the full tradeoff.
 _UPLOAD_LEASE_SECONDS = 900
-_REPO_ROOT = Path(__file__).parents[3]
 
 
 def _try_acquire_upload_lock() -> "IO | None":
@@ -105,21 +104,11 @@ def _try_acquire_upload_lock() -> "IO | None":
         return None
 
 
-def _get_tmp_root() -> Path:
-    """Return the allowed root directory for local video files."""
-    tmp_raw = os.environ.get("VIDEO_TMP_DIR", "")
-    if tmp_raw:
-        p = Path(tmp_raw)
-        return (p if p.is_absolute() else (_REPO_ROOT / p)).resolve()
-    # Default to client-specific data dir so clients never share a tmp directory.
-    return (Path(os.environ["FIELDKIT_DATA_DIR"]) / "photo-agent" / "tmp").resolve()
-
-
 def _delete_local_file(video_local_path: str, project_name: str) -> None:
     """Delete the local temp video file. Best-effort: logs on failure, never raises."""
     try:
         p = Path(video_local_path).resolve()
-        allowed = _get_tmp_root()
+        allowed = paths.get_video_tmp_root()
         try:
             p.relative_to(allowed)
         except ValueError:

--- a/platform/photo-agent/tests/test_check_approval.py
+++ b/platform/photo-agent/tests/test_check_approval.py
@@ -203,6 +203,28 @@ def test_reject_deletes_local_file(base, tmp_path, monkeypatch):
     assert not local_file.exists()
 
 
+def test_reject_deletes_local_file_with_relative_video_tmp_dir(base, tmp_path, monkeypatch):
+    """reject path deletes a video the producer wrote under a RELATIVE VIDEO_TMP_DIR
+    resolved against FIELDKIT_DATA_DIR — the producer/consumer resolution mismatch
+    that #47's review follow-up caught: this script used to resolve the same
+    relative value against the shared repo root instead, so it refused to delete
+    files the fixed producer actually wrote."""
+    import scripts.check_approval as ca
+    client_data_dir = tmp_path / "clients" / "mercury" / "data"
+    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(client_data_dir))
+
+    video_dir = client_data_dir / "data" / "photo-agent" / "tmp" / _PROJECT
+    video_dir.mkdir(parents=True)
+    local_file = video_dir / "video.mp4"
+    local_file.write_bytes(b"\x00" * 64)
+
+    pending = dict(_PENDING, video_local_path=str(local_file))
+    ca.state.get_pending_approval.return_value = pending
+    main(_REJECT_ARGS)
+    assert not local_file.exists()
+
+
 def test_reject_sends_telegram_notification(base):
     """reject path sends a Telegram rejection notification containing '❌'."""
     import scripts.check_approval as ca

--- a/platform/photo-agent/tests/test_paths.py
+++ b/platform/photo-agent/tests/test_paths.py
@@ -1,0 +1,48 @@
+"""
+Tests for tools/paths.py — shared VIDEO_TMP_DIR resolution.
+
+process_photos.py (producer) and check_approval.py / upload_facebook.py
+(the two cleanup consumers) all call tools.paths.get_video_tmp_root() so
+their resolution can't drift apart again — see issue #47, where the
+producer's initial fix left the two consumers independently resolving
+relative paths against the shared repo root instead of FIELDKIT_DATA_DIR.
+These tests cover the three VIDEO_TMP_DIR states (unset, relative,
+absolute) that resolution must handle identically for all three scripts.
+"""
+
+from tools.paths import get_video_tmp_root
+
+
+def test_unset_video_tmp_dir_defaults_to_fieldkit_data_dir_photo_agent_tmp(monkeypatch, tmp_path):
+    """With VIDEO_TMP_DIR unset, the default is <FIELDKIT_DATA_DIR>/photo-agent/tmp."""
+    monkeypatch.delenv("VIDEO_TMP_DIR", raising=False)
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(tmp_path))
+    assert get_video_tmp_root() == (tmp_path / "photo-agent" / "tmp").resolve()
+
+
+def test_relative_video_tmp_dir_resolves_against_fieldkit_data_dir(monkeypatch, tmp_path):
+    """A relative VIDEO_TMP_DIR resolves against FIELDKIT_DATA_DIR, not the repo root."""
+    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(tmp_path))
+    assert get_video_tmp_root() == (tmp_path / "data" / "photo-agent" / "tmp").resolve()
+
+
+def test_absolute_video_tmp_dir_used_as_is(monkeypatch, tmp_path):
+    """An absolute VIDEO_TMP_DIR is used verbatim, ignoring FIELDKIT_DATA_DIR."""
+    absolute = tmp_path / "custom-tmp"
+    monkeypatch.setenv("VIDEO_TMP_DIR", str(absolute))
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(tmp_path / "data"))
+    assert get_video_tmp_root() == absolute.resolve()
+
+
+def test_two_clients_same_relative_video_tmp_dir_resolve_differently(monkeypatch, tmp_path):
+    """Two clients with the same relative VIDEO_TMP_DIR value must not collide (#47)."""
+    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")
+
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(tmp_path / "clients" / "mercury" / "data"))
+    mercury = get_video_tmp_root()
+
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(tmp_path / "clients" / "venus" / "data"))
+    venus = get_video_tmp_root()
+
+    assert mercury != venus

--- a/platform/photo-agent/tests/test_process_photos.py
+++ b/platform/photo-agent/tests/test_process_photos.py
@@ -614,6 +614,47 @@ def test_happy_path_scrub_is_called(happy, env):
 
 
 # ---------------------------------------------------------------------------
+# VIDEO_TMP_DIR resolution — relative paths resolve per-client, not against the
+# shared repo checkout (#47)
+# ---------------------------------------------------------------------------
+
+def test_relative_video_tmp_dir_resolves_against_fieldkit_data_dir(happy, monkeypatch, tmp_path):
+    """A relative VIDEO_TMP_DIR (the shipped .env.example default) resolves under
+    FIELDKIT_DATA_DIR, not the shared fieldkit repo checkout."""
+    import scripts.process_photos as proc
+
+    client_data_dir = tmp_path / "clients" / "mercury" / "data"
+    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")  # the shipped relative default
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(client_data_dir))
+
+    main(["--project", _PROJECT])
+
+    video_local_path = proc.state.set_pending_approval.call_args.args[0]["video_local_path"]
+    repo_root = Path(proc.__file__).resolve().parents[3]
+    assert video_local_path.startswith(str(client_data_dir / "data" / "photo-agent" / "tmp"))
+    assert not video_local_path.startswith(str(repo_root / "data"))
+
+
+def test_two_clients_same_relative_video_tmp_dir_do_not_collide(happy, monkeypatch, tmp_path):
+    """Two clients that ship the same relative VIDEO_TMP_DIR value (as mercury, venus,
+    and _construction_co's .env.example did) must resolve to different absolute tmp
+    directories — the cross-client collision at the heart of #47."""
+    import scripts.process_photos as proc
+
+    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")
+
+    tmp_bases = {}
+    for client in ("mercury", "venus"):
+        monkeypatch.setenv("FIELDKIT_DATA_DIR", str(tmp_path / "clients" / client / "data"))
+        main(["--project", _PROJECT])
+        video_local_path = proc.state.set_pending_approval.call_args.args[0]["video_local_path"]
+        # video_local_path == tmp_base/<project_name>/<file>.mp4
+        tmp_bases[client] = Path(video_local_path).parent.parent
+
+    assert tmp_bases["mercury"] != tmp_bases["venus"]
+
+
+# ---------------------------------------------------------------------------
 # _telegram_error — direct Telegram Bot API notification (replaces openclaw CLI, #14)
 # ---------------------------------------------------------------------------
 #

--- a/platform/photo-agent/tests/test_process_photos.py
+++ b/platform/photo-agent/tests/test_process_photos.py
@@ -619,12 +619,13 @@ def test_happy_path_scrub_is_called(happy, env):
 # ---------------------------------------------------------------------------
 
 def test_relative_video_tmp_dir_resolves_against_fieldkit_data_dir(happy, monkeypatch, tmp_path):
-    """A relative VIDEO_TMP_DIR (the shipped .env.example default) resolves under
-    FIELDKIT_DATA_DIR, not the shared fieldkit repo checkout."""
+    """A relative VIDEO_TMP_DIR (the formerly shipped .env.example default, now
+    commented out — see #47) resolves under FIELDKIT_DATA_DIR, not the shared
+    fieldkit repo checkout."""
     import scripts.process_photos as proc
 
     client_data_dir = tmp_path / "clients" / "mercury" / "data"
-    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")  # the shipped relative default
+    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")  # the formerly shipped relative default
     monkeypatch.setenv("FIELDKIT_DATA_DIR", str(client_data_dir))
 
     main(["--project", _PROJECT])
@@ -636,9 +637,10 @@ def test_relative_video_tmp_dir_resolves_against_fieldkit_data_dir(happy, monkey
 
 
 def test_two_clients_same_relative_video_tmp_dir_do_not_collide(happy, monkeypatch, tmp_path):
-    """Two clients that ship the same relative VIDEO_TMP_DIR value (as mercury, venus,
-    and _construction_co's .env.example did) must resolve to different absolute tmp
-    directories — the cross-client collision at the heart of #47."""
+    """Two clients that set the same relative VIDEO_TMP_DIR value (as mercury, venus,
+    and _construction_co's .env.example formerly did, uncommented — see #47) must
+    resolve to different absolute tmp directories — the cross-client collision at the
+    heart of #47."""
     import scripts.process_photos as proc
 
     monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")

--- a/platform/photo-agent/tests/test_upload_facebook.py
+++ b/platform/photo-agent/tests/test_upload_facebook.py
@@ -162,6 +162,30 @@ def test_happy_path_deletes_local_file_after_published(with_pending, tmp_path, m
     assert not Path(video_path).exists()
 
 
+def test_happy_path_deletes_local_file_with_relative_video_tmp_dir(base, tmp_path, monkeypatch):
+    """On success, a video the producer wrote under a RELATIVE VIDEO_TMP_DIR resolved
+    against FIELDKIT_DATA_DIR is still deleted — the producer/consumer resolution
+    mismatch that #47's review follow-up caught: this script used to resolve the same
+    relative value against the shared repo root instead, so it refused to delete files
+    the fixed producer actually wrote."""
+    import scripts.upload_facebook as uf
+    client_data_dir = tmp_path / "clients" / "mercury" / "data"
+    monkeypatch.setenv("VIDEO_TMP_DIR", "data/photo-agent/tmp")
+    monkeypatch.setenv("FIELDKIT_DATA_DIR", str(client_data_dir))
+
+    video_dir = client_data_dir / "data" / "photo-agent" / "tmp" / _PROJECT
+    video_dir.mkdir(parents=True)
+    video_path = video_dir / "video.mp4"
+    video_path.write_bytes(b"\x00" * 64)
+
+    record = dict(_PENDING_RECORD, video_local_path=str(video_path))
+    uf.facebook_state.get_pending_upload.return_value = record
+
+    assert video_path.exists()
+    main([])
+    assert not video_path.exists()
+
+
 def test_happy_path_sends_telegram_confirmation(with_pending):
     """On success, send_message is called with a URL pointing to the Facebook post."""
     import scripts.upload_facebook as uf

--- a/platform/photo-agent/tools/paths.py
+++ b/platform/photo-agent/tools/paths.py
@@ -1,0 +1,31 @@
+"""
+paths.py — Shared VIDEO_TMP_DIR resolution for the photo-video agent.
+
+process_photos.py (the producer) and check_approval.py / upload_facebook.py
+(the two cleanup consumers) must resolve VIDEO_TMP_DIR identically, or
+cleanup refuses to delete files it doesn't recognize as inside the allowed
+tmp root. Issue #47 fixed the producer's resolution to use FIELDKIT_DATA_DIR
+instead of the shared repo root, but the two consumers each carried their
+own independent copy of the same logic and were missed by that fix — this
+module is the single shared implementation so the three call sites can't
+drift apart again.
+"""
+
+import os
+from pathlib import Path
+
+
+def get_video_tmp_root() -> Path:
+    """Return the resolved VIDEO_TMP_DIR root.
+
+    A relative VIDEO_TMP_DIR resolves against FIELDKIT_DATA_DIR (the
+    per-client dir), never the shared fieldkit repo checkout — otherwise
+    every client whose .env ships the same relative default collides on one
+    shared tmp directory (issue #47).
+    """
+    tmp_raw = os.environ.get("VIDEO_TMP_DIR", "")
+    data_dir = Path(os.environ["FIELDKIT_DATA_DIR"])
+    if tmp_raw:
+        p = Path(tmp_raw)
+        return (p if p.is_absolute() else (data_dir / p)).resolve()
+    return (data_dir / "photo-agent" / "tmp").resolve()


### PR DESCRIPTION
## Summary
- `process_photos.py` resolved a relative `VIDEO_TMP_DIR` against `_REPO_ROOT` (the shared fieldkit checkout) instead of `FIELDKIT_DATA_DIR` (the per-client dir). Every client's `.env.example` — mercury, venus, `_construction_co`, and even `_demo`'s tracked example — ships the same relative default (`data/photo-agent/tmp`), so all of them collided on one shared cross-client tmp directory.
- Code fix: relative `VIDEO_TMP_DIR` now resolves against `FIELDKIT_DATA_DIR`, making the safe per-client behavior the default even when the var is explicitly set (not just when it's unset).
- Belt-and-suspenders: commented out `VIDEO_TMP_DIR` by default in all client `.env.example` files (mercury, venus, `_construction_co`, `_demo`) and the `platform/photo-agent/.env.example` template, so any future client scaffolded from the template inherits the safe unset default. Also corrected a stale comment in the template that claimed relative paths resolve against `FIELDKIT_ROOT`.

Closes #47

## Review follow-up (codex)
codex's cross-review caught that the first pass only fixed the producer (`process_photos.py`) — `check_approval.py` and `upload_facebook.py` each carried an independent copy of the same resolution logic in their own `_get_tmp_root()`, still resolving relative paths against the shared repo root. With a relative `VIDEO_TMP_DIR` set, that meant the producer would write under `FIELDKIT_DATA_DIR` while these two cleanup paths computed the allowed root under the repo root, so post-rejection and post-Facebook-upload cleanup refused to delete the newly generated videos — a local video file leak.

Fixed by extracting the resolution logic into `tools/paths.get_video_tmp_root()`, now the single shared implementation used by all three scripts, so they can't drift apart again. Added `tests/test_paths.py` (unset/relative/absolute coverage) plus one regression test per consumer proving cleanup now finds and deletes a video generated under a relative `VIDEO_TMP_DIR` — verified both fail against the pre-fix consumer code with the exact "refused to delete file outside tmp directory" symptom.

**Live-deploy note (not done in this PR):** any already-deployed client's real, gitignored `.env` on the Mac Mini that sets an explicit *relative* `VIDEO_TMP_DIR` will see a real behavior change from this fix — the resolved tmp root moves from `<repo_root>/...` to `<FIELDKIT_DATA_DIR>/...`. Before this deploys live, audit each deployed client's `.env` for an uncommented relative `VIDEO_TMP_DIR` and either update it or comment it out to pick up the safe default. Not performed as part of this PR.

## Test plan
- [x] New regression test `test_two_clients_same_relative_video_tmp_dir_do_not_collide` — proves two clients with the same relative `VIDEO_TMP_DIR` resolve to different absolute tmp directories. Verified it fails against the pre-fix code (reproduces the exact collision from the issue) and passes after the fix.
- [x] New test `test_relative_video_tmp_dir_resolves_against_fieldkit_data_dir` — proves the resolved path lands under `FIELDKIT_DATA_DIR`, not the repo root.
- [x] New `tests/test_paths.py` — unit coverage of `get_video_tmp_root()` for unset, relative, and absolute `VIDEO_TMP_DIR`.
- [x] New `test_reject_deletes_local_file_with_relative_video_tmp_dir` (check_approval) and `test_happy_path_deletes_local_file_with_relative_video_tmp_dir` (upload_facebook) — prove both cleanup consumers now correctly delete videos the producer generated under a relative `VIDEO_TMP_DIR`. Verified both fail against the pre-follow-up consumer code.
- [x] Full `platform/photo-agent` suite: 420 passed.
