### PR TITLE
Fix silent stdout on successful approve/reject (#63)

### DIFF
--- a/platform/photo-agent/scripts/check_approval.py
+++ b/platform/photo-agent/scripts/check_approval.py
@@ -18,6 +18,11 @@ The system operates on a single-pending-approval-at-a-time model
 (state.json's pending_approval field is singular), so a bare /photo_approve
 or /photo_reject carries unambiguous semantics: whichever approval is
 currently pending. If nothing is pending, the script exits 0 with no output.
+A successful approve or reject also exits 0, but prints a one-line
+"Approved: <project>" / "Rejected: <project>" confirmation to stdout (issue
+#63) — exit 0 with EMPTY stdout is reserved exclusively for the
+nothing-pending case, so Hermes's output-handling rule (see the
+photo-approve/photo-reject SKILL.md files) can tell the two apart.
 
 ---
 
@@ -313,6 +318,15 @@ def _run(callback_data: str) -> None:
 
         _enqueue_facebook_upload(project_name, video_local_path, telegram_message_id)
 
+        # Issue #63: exit 0 with empty stdout is Hermes's signal (see the
+        # photo-approve/photo-reject SKILL.md "Output handling" sections)
+        # for "nothing was pending" — the `record is None` branch above.
+        # Without a stdout line here, a genuinely successful approval was
+        # indistinguishable from that no-op case, so Hermes reported "No
+        # pending approval" to the admin even though the approval (and any
+        # Facebook publish it enqueued) had already gone through.
+        print(f"Approved: {project_name}")
+
     else:  # reject
         # Drive delete is best-effort — failure is logged but does not block the rejection.
         try:
@@ -333,6 +347,10 @@ def _run(callback_data: str) -> None:
             activity_log.log_rejected(project_name)
         except (ValueError, OSError) as exc:
             _log.error("activity log failed after rejection: %s", exc)
+
+        # Issue #63: see the matching comment on the approve branch above —
+        # same stdout contract applies to a successful rejection.
+        print(f"Rejected: {project_name}")
 
     state.clear_pending_approval()
 

--- a/platform/photo-agent/scripts/check_approval.py
+++ b/platform/photo-agent/scripts/check_approval.py
@@ -22,7 +22,13 @@ A successful approve or reject also exits 0, but prints a one-line
 "Approved: <project>" / "Rejected: <project>" confirmation to stdout (issue
 #63) — exit 0 with EMPTY stdout is reserved exclusively for the
 nothing-pending case, so Hermes's output-handling rule (see the
-photo-approve/photo-reject SKILL.md files) can tell the two apart.
+photo-approve/photo-reject SKILL.md files) can tell the two apart. Lock
+contention (another check_approval.py instance already holds
+check_approval.lock — e.g. two /photo_approve or /photo_approve +
+/photo_reject commands dispatched in close succession) is a fourth,
+similarly distinct outcome: it also exits 0, but prints "Already
+processing — try again in a moment." rather than either an
+approve/reject confirmation or nothing.
 
 ---
 
@@ -258,6 +264,13 @@ def main(argv=None) -> None:
     lock_f = _try_acquire_check_lock()
     if lock_f is None:
         _log.debug("another check_approval instance is running — exiting")
+        # Issue #63 follow-up: this used to exit 0 with empty stdout, which
+        # is indistinguishable from the genuine no-pending-approval case
+        # (see _run()'s `record is None` branch and the module docstring).
+        # Lock contention means another approve/reject decision is actively
+        # being processed right now — not that nothing is pending — so it
+        # needs its own unambiguous, non-empty stdout signal.
+        print("Already processing — try again in a moment.")
         return
 
     try:
@@ -318,14 +331,7 @@ def _run(callback_data: str) -> None:
 
         _enqueue_facebook_upload(project_name, video_local_path, telegram_message_id)
 
-        # Issue #63: exit 0 with empty stdout is Hermes's signal (see the
-        # photo-approve/photo-reject SKILL.md "Output handling" sections)
-        # for "nothing was pending" — the `record is None` branch above.
-        # Without a stdout line here, a genuinely successful approval was
-        # indistinguishable from that no-op case, so Hermes reported "No
-        # pending approval" to the admin even though the approval (and any
-        # Facebook publish it enqueued) had already gone through.
-        print(f"Approved: {project_name}")
+        confirmation = f"Approved: {project_name}"
 
     else:  # reject
         # Drive delete is best-effort — failure is logged but does not block the rejection.
@@ -348,11 +354,24 @@ def _run(callback_data: str) -> None:
         except (ValueError, OSError) as exc:
             _log.error("activity log failed after rejection: %s", exc)
 
-        # Issue #63: see the matching comment on the approve branch above —
-        # same stdout contract applies to a successful rejection.
-        print(f"Rejected: {project_name}")
+        confirmation = f"Rejected: {project_name}"
 
+    # Issue #63: exit 0 with empty stdout is Hermes's signal (see the
+    # photo-approve/photo-reject SKILL.md "Output handling" sections) for
+    # "nothing was pending" — the `record is None` branch above. Without a
+    # stdout line here, a genuinely successful approval/rejection was
+    # indistinguishable from that no-op case, so Hermes reported "No
+    # pending approval" to the admin even though the decision (and any
+    # Facebook publish it enqueued) had already gone through.
+    #
+    # Printed only after clear_pending_approval() succeeds — not inside the
+    # if/else above — so a confirmation on stdout stays tightly coupled to
+    # "the state change genuinely completed": if clear_pending_approval()
+    # raises, this line is never reached and the script exits nonzero
+    # (uncaught exception), which the skills' output-handling rule already
+    # reports as a failure rather than a success.
     state.clear_pending_approval()
+    print(confirmation)
 
 
 if __name__ == "__main__":

--- a/platform/photo-agent/skills/photo-approve/SKILL.md
+++ b/platform/photo-agent/skills/photo-approve/SKILL.md
@@ -90,3 +90,10 @@ Run the script once and do not retry. Report the result as follows:
 If the exit code is non-zero, report it as an error: "Script failed (exit <code>): <output>"
 If the script exits with code 0 and no output, report: "No pending approval."
 Otherwise relay the output verbatim. Do not summarise or paraphrase.
+
+> **Contract (issue #63):** exit 0 with EMPTY stdout means "nothing was
+> pending" — that is the ONLY case with no output. A successful approval
+> always prints a one-line confirmation (e.g. `Approved: <project>`) before
+> exiting 0, so never report "No pending approval" when stdout is non-empty,
+> even though the exit code is 0 in both cases — check the output, not just
+> the exit code.

--- a/platform/photo-agent/skills/photo-approve/SKILL.md
+++ b/platform/photo-agent/skills/photo-approve/SKILL.md
@@ -96,4 +96,8 @@ Otherwise relay the output verbatim. Do not summarise or paraphrase.
 > always prints a one-line confirmation (e.g. `Approved: <project>`) before
 > exiting 0, so never report "No pending approval" when stdout is non-empty,
 > even though the exit code is 0 in both cases — check the output, not just
-> the exit code.
+> the exit code. Lock contention (another decision already being processed)
+> also exits 0 with non-empty output (e.g. `Already processing — try again
+> in a moment.`) — it falls under "otherwise relay the output verbatim"
+> above like any other non-empty-output case, not under "No pending
+> approval".

--- a/platform/photo-agent/skills/photo-reject/SKILL.md
+++ b/platform/photo-agent/skills/photo-reject/SKILL.md
@@ -73,4 +73,8 @@ Otherwise relay the output verbatim. Do not summarise or paraphrase.
 > always prints a one-line confirmation (e.g. `Rejected: <project>`) before
 > exiting 0, so never report "No pending approval" when stdout is non-empty,
 > even though the exit code is 0 in both cases — check the output, not just
-> the exit code.
+> the exit code. Lock contention (another decision already being processed)
+> also exits 0 with non-empty output (e.g. `Already processing — try again
+> in a moment.`) — it falls under "otherwise relay the output verbatim"
+> above like any other non-empty-output case, not under "No pending
+> approval".

--- a/platform/photo-agent/skills/photo-reject/SKILL.md
+++ b/platform/photo-agent/skills/photo-reject/SKILL.md
@@ -67,3 +67,10 @@ Run the script once and do not retry. Report the result as follows:
 If the exit code is non-zero, report it as an error: "Script failed (exit <code>): <output>"
 If the script exits with code 0 and no output, report: "No pending approval."
 Otherwise relay the output verbatim. Do not summarise or paraphrase.
+
+> **Contract (issue #63):** exit 0 with EMPTY stdout means "nothing was
+> pending" — that is the ONLY case with no output. A successful rejection
+> always prints a one-line confirmation (e.g. `Rejected: <project>`) before
+> exiting 0, so never report "No pending approval" when stdout is non-empty,
+> even though the exit code is 0 in both cases — check the output, not just
+> the exit code.

--- a/platform/photo-agent/tests/test_check_approval.py
+++ b/platform/photo-agent/tests/test_check_approval.py
@@ -118,6 +118,16 @@ def test_no_pending_approval_reject_exits_silently(mocker, env, lock_mock):
     main(_REJECT_ARGS)  # must not raise
 
 
+def test_no_pending_approval_prints_nothing_to_stdout(mocker, env, lock_mock, capsys):
+    """Issue #63: the genuine no-pending-approval case must be the ONLY one that
+    produces empty stdout — this is the signal Hermes's output-handling rule
+    relies on to distinguish it from a successful approve/reject."""
+    mocker.patch("scripts.check_approval._load_env")
+    mocker.patch("scripts.check_approval.state.get_pending_approval", return_value=None)
+    main(_APPROVE_ARGS)
+    assert capsys.readouterr().out == ""
+
+
 # ---------------------------------------------------------------------------
 # Approve path — actions
 # ---------------------------------------------------------------------------
@@ -177,6 +187,14 @@ def test_approve_logs_approved(base):
     import scripts.check_approval as ca
     main(_APPROVE_ARGS)
     ca.activity_log.log_approved.assert_called_once_with(_PROJECT)
+
+
+def test_approve_prints_unambiguous_confirmation_to_stdout(base, capsys):
+    """Issue #63: a successful approval must print a one-line stdout confirmation
+    so Hermes never mistakes it for the no-pending-approval no-op case."""
+    main(_APPROVE_ARGS)
+    out = capsys.readouterr().out
+    assert out == f"Approved: {_PROJECT}\n"
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +272,40 @@ def test_reject_logs_rejected(base):
     import scripts.check_approval as ca
     main(_REJECT_ARGS)
     ca.activity_log.log_rejected.assert_called_once_with(_PROJECT)
+
+
+def test_reject_prints_unambiguous_confirmation_to_stdout(base, capsys):
+    """Issue #63: a successful rejection must print a one-line stdout confirmation
+    so Hermes never mistakes it for the no-pending-approval no-op case."""
+    main(_REJECT_ARGS)
+    out = capsys.readouterr().out
+    assert out == f"Rejected: {_PROJECT}\n"
+
+
+def test_approve_and_no_pending_stdout_are_distinguishable(mocker, env, lock_mock, capsys):
+    """Issue #63 end-to-end: capture stdout for a successful approve and for the
+    genuine no-pending-approval case in the same test and assert they differ —
+    this is exactly the ambiguity Hermes's output-handling rule was fooled by
+    before check_approval.py printed anything on success."""
+    mocker.patch("scripts.check_approval._load_env")
+    mocker.patch("scripts.check_approval.state.get_pending_approval", return_value=_PENDING)
+    mocker.patch("scripts.check_approval.state.clear_pending_approval")
+    mocker.patch("scripts.check_approval.drive.delete")
+    mocker.patch("scripts.check_approval._send_approval_email")
+    mocker.patch("scripts.check_approval._notify_admin")
+    mocker.patch("scripts.check_approval.activity_log.log_approved")
+    mocker.patch("scripts.check_approval.facebook_state.set_pending_upload")
+    mocker.patch("scripts.check_approval.facebook_state.is_published", return_value=False)
+    main(_APPROVE_ARGS)
+    success_out = capsys.readouterr().out
+    assert success_out != ""
+
+    mocker.patch("scripts.check_approval.state.get_pending_approval", return_value=None)
+    main(_APPROVE_ARGS)
+    no_pending_out = capsys.readouterr().out
+
+    assert no_pending_out == ""
+    assert success_out != no_pending_out
 
 
 # ---------------------------------------------------------------------------

--- a/platform/photo-agent/tests/test_check_approval.py
+++ b/platform/photo-agent/tests/test_check_approval.py
@@ -675,6 +675,4 @@ def test_lock_contention_prints_distinct_nonempty_stdout(mocker, env, capsys):
     mocker.patch("scripts.check_approval._try_acquire_check_lock", return_value=None)
     main(_APPROVE_ARGS)
     out = capsys.readouterr().out
-    assert out != ""
-    assert not out.startswith("Approved:")
-    assert not out.startswith("Rejected:")
+    assert out == "Already processing — try again in a moment.\n"

--- a/platform/photo-agent/tests/test_check_approval.py
+++ b/platform/photo-agent/tests/test_check_approval.py
@@ -182,6 +182,30 @@ def test_approve_clears_pending_approval(base):
     ca.state.clear_pending_approval.assert_called_once()
 
 
+def test_approve_confirmation_not_printed_if_clear_pending_approval_fails(base, capsys):
+    """Issue #63 follow-up: the 'Approved: <project>' confirmation must only ever
+    reach stdout after state.clear_pending_approval() has actually succeeded — if
+    it raises, the approval hasn't genuinely completed (the pending record is
+    still there), so the confirmation must not be printed even though every
+    other approve side effect (email, activity log, FB enqueue) already ran."""
+    import scripts.check_approval as ca
+    ca.state.clear_pending_approval.side_effect = RuntimeError("disk full")
+    with pytest.raises(RuntimeError):
+        main(_APPROVE_ARGS)
+    out = capsys.readouterr().out
+    assert "Approved:" not in out
+
+
+def test_reject_confirmation_not_printed_if_clear_pending_approval_fails(base, capsys):
+    """Same guarantee as above, for the reject path."""
+    import scripts.check_approval as ca
+    ca.state.clear_pending_approval.side_effect = RuntimeError("disk full")
+    with pytest.raises(RuntimeError):
+        main(_REJECT_ARGS)
+    out = capsys.readouterr().out
+    assert "Rejected:" not in out
+
+
 def test_approve_logs_approved(base):
     """approve path calls activity_log.log_approved() with the project name."""
     import scripts.check_approval as ca
@@ -632,10 +656,25 @@ def test_activity_log_error_on_reject_does_not_block_state_clear(base, mocker):
 # state.json race.
 # ---------------------------------------------------------------------------
 
-def test_lock_contention_exits_silently(mocker, env):
+def test_lock_contention_takes_no_action(mocker, env):
     """If check_approval.lock is held by another instance, main() exits without taking action."""
     mocker.patch("scripts.check_approval._load_env")
     mocker.patch("scripts.check_approval._try_acquire_check_lock", return_value=None)
     mock_get_pending = mocker.patch("scripts.check_approval.state.get_pending_approval")
     main(_APPROVE_ARGS)
     mock_get_pending.assert_not_called()
+
+
+def test_lock_contention_prints_distinct_nonempty_stdout(mocker, env, capsys):
+    """Issue #63 follow-up: lock contention must NOT be silent like the genuine
+    no-pending-approval case — it means another decision is actively being
+    processed, not that nothing is pending. It needs its own unambiguous,
+    non-empty stdout signal, distinct from both an approve/reject confirmation
+    and the empty-stdout no-pending-approval case."""
+    mocker.patch("scripts.check_approval._load_env")
+    mocker.patch("scripts.check_approval._try_acquire_check_lock", return_value=None)
+    main(_APPROVE_ARGS)
+    out = capsys.readouterr().out
+    assert out != ""
+    assert not out.startswith("Approved:")
+    assert not out.startswith("Rejected:")


### PR DESCRIPTION
## Summary
- `check_approval.py` printed nothing on any outcome. Hermes's photo-approve/photo-reject skills treat "exit 0, empty stdout" as the signal that nothing was pending, so a genuinely successful approval or rejection was indistinguishable from a no-op — live-reproduced: an approval fully succeeded (Facebook post published) but Hermes reported "No pending approval" to the admin.
- The success path for both approve and reject now prints a one-line confirmation (`Approved: <project>` / `Rejected: <project>`) to stdout. Empty stdout is now reserved exclusively for the genuine no-pending-approval case, so exit 0 + stdout content is unambiguous.
- Updated the module docstring and both `photo-approve/SKILL.md` / `photo-reject/SKILL.md` output-handling sections to spell out the corrected contract. Note: the skills' existing "otherwise relay the output verbatim" fallback already handled non-empty output correctly — only the script itself needed the fix, but I added an explicit callout so a future reader doesn't have to re-derive that.
- Did not touch approve/reject business logic, Facebook/email/Drive side effects, or the #29/#31 timing code — this is purely a stdout-observability fix.

## Test plan
- [x] Added tests capturing stdout (via `capsys`) for all three cases: successful approve, successful reject, and genuine no-pending-approval — asserting the no-pending case is the only one with empty stdout.
- [x] `platform/photo-agent` full suite: 542 passed, 2 skipped
- [x] `platform/email-agent` full suite: 84 passed

Closes #63