### PR TITLE
Add progress bar overlay to e2e test video frames

### DIFF
--- a/platform/photo-agent/scripts/e2e_stage1_generate_frames.py
+++ b/platform/photo-agent/scripts/e2e_stage1_generate_frames.py
@@ -93,6 +93,7 @@ def _generate_clock_frames(n_frames: int, start_unix: int, frames_dir: Path) -> 
     ]
 
     W, H = 1080, 1920
+    PROGRESS_BAR_HEIGHT = 6
     for i in range(n_frames):
         ts = datetime.fromtimestamp(start_unix + i)
         bg_color = _PALETTE[i % len(_PALETTE)]
@@ -109,6 +110,12 @@ def _generate_clock_frames(n_frames: int, start_unix: int, frames_dir: Path) -> 
                   ts.strftime("%m/%d/%Y"), font=font_date, fill="white")
         draw.text((cx(ts.strftime("%H:%M:%S"), font_time), int(H * 0.62)),
                   ts.strftime("%H:%M:%S"), font=font_time, fill="white")
+
+        # Progress indicator: thin bar at bottom showing (i+1)/n_frames progress
+        progress = (i + 1) / n_frames
+        bar_width = int(W * progress)
+        bar_y = H - PROGRESS_BAR_HEIGHT
+        draw.rectangle([(0, bar_y), (bar_width, H)], fill=(255, 255, 255, 230))
 
         img.save(frames_dir / f"frame_{i + 1:03d}.jpg", "JPEG", quality=90)
 

--- a/platform/photo-agent/tests/test_run_e2e_test.py
+++ b/platform/photo-agent/tests/test_run_e2e_test.py
@@ -227,6 +227,83 @@ def test_generate_clock_frames_distinct_background_colors(tmp_path):
         f"Expected at least 8 distinct colors, got {len(unique_colors)}"
 
 
+def test_generate_clock_frames_progress_bar_grows_monotonically(tmp_path):
+    """Progress bar width increases monotonically from first to last frame."""
+    from PIL import Image
+    n_frames = 8
+    _generate_clock_frames(n_frames, 1700000000, tmp_path)
+    frames = sorted(tmp_path.glob("frame_*.jpg"))
+
+    # Measure the width of the white progress bar at the bottom of each frame
+    bar_widths = []
+    for frame_path in frames:
+        with Image.open(frame_path) as img:
+            width, height = img.size
+            # Sample the bottom row to count white pixels (progress bar)
+            bottom_y = height - 3  # Middle of the 6px tall bar
+            white_count = 0
+            for x in range(width):
+                pixel = img.getpixel((x, bottom_y))
+                # White or near-white pixel (accounting for JPEG compression)
+                if all(c >= 240 for c in pixel):
+                    white_count += 1
+            bar_widths.append(white_count)
+
+    # Verify monotonic growth
+    for i in range(len(bar_widths) - 1):
+        assert bar_widths[i] < bar_widths[i + 1], \
+            f"Progress bar width did not increase from frame {i} to {i+1}: " \
+            f"{bar_widths[i]} >= {bar_widths[i+1]}"
+
+
+def test_generate_clock_frames_progress_bar_first_vs_last(tmp_path):
+    """First frame has small progress bar, last frame has full-width progress bar."""
+    from PIL import Image
+    n_frames = 10
+    _generate_clock_frames(n_frames, 1700000000, tmp_path)
+    frames = sorted(tmp_path.glob("frame_*.jpg"))
+
+    first_frame = frames[0]
+    last_frame = frames[-1]
+
+    with Image.open(first_frame) as img:
+        width, height = img.size
+        bottom_y = height - 3
+        first_white_count = sum(1 for x in range(width)
+                                if all(c >= 240 for c in img.getpixel((x, bottom_y))))
+
+    with Image.open(last_frame) as img:
+        bottom_y = height - 3
+        last_white_count = sum(1 for x in range(width)
+                               if all(c >= 240 for c in img.getpixel((x, bottom_y))))
+
+    # First frame should have ~1/n_frames width, last frame should have full width
+    assert first_white_count < width // 2, \
+        f"First frame progress bar too wide: {first_white_count} >= {width // 2}"
+    assert last_white_count > width * 0.95, \
+        f"Last frame progress bar not full-width: {last_white_count} <= {width * 0.95}"
+
+
+def test_generate_clock_frames_single_frame_no_crash(tmp_path):
+    """Generating a single frame (n_frames=1) does not crash and produces valid output."""
+    from PIL import Image
+    _generate_clock_frames(1, 1700000000, tmp_path)
+    frames = sorted(tmp_path.glob("frame_*.jpg"))
+    assert len(frames) == 1
+
+    # Verify the frame is valid and has a full-width progress bar (100% for 1/1)
+    with Image.open(frames[0]) as img:
+        width, height = img.size
+        assert width == 1080
+        assert height == 1920
+        # Check that progress bar is full-width
+        bottom_y = height - 3
+        white_count = sum(1 for x in range(width)
+                          if all(c >= 240 for c in img.getpixel((x, bottom_y))))
+        assert white_count > width * 0.95, \
+            f"Single frame progress bar not full-width: {white_count} <= {width * 0.95}"
+
+
 # ---------------------------------------------------------------------------
 # T014: Stage 2 — _upload_frames_to_drive
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds a subtle 6-pixel-tall white progress bar overlay to each synthetic e2e test video frame, showing how far through the video sequence that frame is.

## Design
- **Bar height**: 6 pixels
- **Anchoring**: Bottom edge of frame (y = 1920 - 6)
- **Progress formula**: `(i+1) / n_frames` — frame 0 shows 1/n completion, frame n-1 shows 100%
- **Fill**: White rectangle from x=0 to x=`width * progress`
- **Deterministic**: Based solely on frame index and n_frames (no randomness, no wall-clock dependency)
- **Edge case handling**: n_frames=1 works correctly (shows 100% bar)

## Visual impact
- **Subtle**: 6px bar at the bottom is unobtrusive, doesn't compete with the clock/date/label text
- **Preserves existing contracts**: Does NOT touch pixel (10, 10) — the existing `test_generate_clock_frames_distinct_background_colors` test samples that pixel to verify per-frame background color distinctness, and continues to pass

## Test coverage
Three new tests in `platform/photo-agent/tests/test_run_e2e_test.py`:
- `test_generate_clock_frames_progress_bar_grows_monotonically` — bar width increases frame-to-frame
- `test_generate_clock_frames_progress_bar_first_vs_last` — first frame has small bar (~10% width), last frame has full-width bar
- `test_generate_clock_frames_single_frame_no_crash` — n_frames=1 doesn't crash and produces a valid frame with full-width bar

## Test results
All 42 tests in `test_run_e2e_test.py` pass:
```
============================== 42 passed in 0.29s ==============================
```

## Files changed
- `platform/photo-agent/scripts/e2e_stage1_generate_frames.py` — added 6-line progress bar drawing code
- `platform/photo-agent/tests/test_run_e2e_test.py` — added 3 new tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)