### PR TITLE
Add freeze-frame hold to end of generated slideshow videos

### DIFF
--- a/platform/photo-agent/scripts/process_photos.py
+++ b/platform/photo-agent/scripts/process_photos.py
@@ -260,7 +260,7 @@ def main(argv=None) -> None:
             _telegram_error(f"❌ {project_name}: video generation failed — {exc}")
 
         xfade = cfg.crossfade_duration
-        duration_sec = n * spp - (n - 1) * xfade
+        duration_sec = n * spp - (n - 1) * xfade + cfg.freeze_duration
         activity_log.log_generated(project_name, duration_sec, output_path.stat().st_size)
 
         # Upload video to Drive; retain local file on failure for manual recovery

--- a/platform/photo-agent/tests/test_process_photos.py
+++ b/platform/photo-agent/tests/test_process_photos.py
@@ -598,7 +598,7 @@ def test_happy_path_message_includes_project_name_count_and_duration(happy, env)
     _, text = proc.telegram_api.send_message.call_args.args
     assert _PROJECT in text
     assert "2" in text          # photo count
-    assert "7.5" in text        # duration: 2 × 4s − 1 × 0.5s = 7.5s
+    assert "9" in text          # duration: 2 × 4s − 1 × 0.5s + 1.5s freeze = 9s
 
 
 def test_happy_path_scrub_is_called(happy, env):

--- a/platform/photo-agent/tests/test_video_generator.py
+++ b/platform/photo-agent/tests/test_video_generator.py
@@ -78,6 +78,7 @@ def test_videoconfig_defaults():
     assert cfg.seconds_per_photo == 4
     assert cfg.crossfade_duration == 0.5
     assert cfg.bitrate == "3M"
+    assert cfg.freeze_duration == 1.5
 
 
 def test_videoconfig_rejects_negative_crossfade():
@@ -92,6 +93,12 @@ def test_videoconfig_rejects_crossfade_gte_spp():
         VideoConfig(seconds_per_photo=4, crossfade_duration=4.0)
     with pytest.raises(ValueError, match="crossfade_duration"):
         VideoConfig(seconds_per_photo=4, crossfade_duration=5.0)
+
+
+def test_videoconfig_rejects_negative_freeze_duration():
+    """VideoConfig raises ValueError when freeze_duration is negative."""
+    with pytest.raises(ValueError, match="freeze_duration"):
+        VideoConfig(freeze_duration=-0.1)
 
 
 # ---------------------------------------------------------------------------
@@ -128,8 +135,8 @@ def test_n1_no_xfade(tmp_path, gen, mock_ffmpeg_ok):
 
 
 def test_n1_maps_v0_not_xout(tmp_path, gen, mock_ffmpeg_ok):
-    """For N=1, the -map flag uses [v0], not [xout] (there is no xfade output)."""
-    gen.generate(make_photos(tmp_path, 1), VideoConfig(), tmp_path / "out.mp4")
+    """For N=1 with freeze disabled, the -map flag uses [v0], not [xout] (there is no xfade output)."""
+    gen.generate(make_photos(tmp_path, 1), VideoConfig(freeze_duration=0), tmp_path / "out.mp4")
     cmd = get_cmd(mock_ffmpeg_ok)
     assert cmd[cmd.index("-map") + 1] == "[v0]"
     assert "[xout]" not in cmd
@@ -217,6 +224,40 @@ def test_n11_unique_filter_labels(tmp_path, gen, mock_ffmpeg_ok):
 
 
 # ---------------------------------------------------------------------------
+# Freeze-frame hold (freeze_duration)
+# ---------------------------------------------------------------------------
+
+def test_freeze_single_photo_adds_tpad_and_remaps(tmp_path, gen, mock_ffmpeg_ok):
+    """For N=1 with freeze_duration > 0, a tpad filter is appended and -map targets [vout]."""
+    cfg = VideoConfig(freeze_duration=1.5)
+    gen.generate(make_photos(tmp_path, 1), cfg, tmp_path / "out.mp4")
+    cmd = get_cmd(mock_ffmpeg_ok)
+    fc = get_filter_complex(cmd)
+    assert "[v0]tpad=stop_mode=clone:stop_duration=1.5[vout]" in fc
+    assert cmd[cmd.index("-map") + 1] == "[vout]"
+
+
+def test_freeze_multi_photo_adds_tpad_after_xfade_and_remaps(tmp_path, gen, mock_ffmpeg_ok):
+    """For N=2 with freeze_duration > 0, tpad is chained after [xout] and -map targets [vout]."""
+    cfg = VideoConfig(freeze_duration=2.0)
+    gen.generate(make_photos(tmp_path, 2), cfg, tmp_path / "out.mp4")
+    cmd = get_cmd(mock_ffmpeg_ok)
+    fc = get_filter_complex(cmd)
+    assert "[xout]tpad=stop_mode=clone:stop_duration=2[vout]" in fc
+    assert cmd[cmd.index("-map") + 1] == "[vout]"
+
+
+def test_freeze_zero_disables_tpad(tmp_path, gen, mock_ffmpeg_ok):
+    """freeze_duration=0 omits the tpad filter entirely and keeps the original map label."""
+    cfg = VideoConfig(freeze_duration=0)
+    gen.generate(make_photos(tmp_path, 2), cfg, tmp_path / "out.mp4")
+    cmd = get_cmd(mock_ffmpeg_ok)
+    fc = get_filter_complex(cmd)
+    assert "tpad" not in fc
+    assert cmd[cmd.index("-map") + 1] == "[xout]"
+
+
+# ---------------------------------------------------------------------------
 # Scale/crop filter
 # ---------------------------------------------------------------------------
 
@@ -258,7 +299,7 @@ def test_n1_actual_output_duration_matches_seconds_per_photo(tmp_path, real_test
         pytest.skip("ffmpeg/ffprobe not available")
 
     gen = FFmpegVideoGenerator()
-    cfg = VideoConfig(seconds_per_photo=2, fps=30)
+    cfg = VideoConfig(seconds_per_photo=2, fps=30, freeze_duration=0)
     output = tmp_path / "out.mp4"
 
     gen.generate([real_test_image], cfg, output)
@@ -313,7 +354,7 @@ def test_n2_actual_output_duration_matches_xfade_formula(tmp_path, real_test_ima
         pytest.skip("ffmpeg/ffprobe not available")
 
     gen = FFmpegVideoGenerator()
-    cfg = VideoConfig(seconds_per_photo=3, crossfade_duration=0.5, fps=30)
+    cfg = VideoConfig(seconds_per_photo=3, crossfade_duration=0.5, fps=30, freeze_duration=0)
     output = tmp_path / "out.mp4"
 
     # Create second test image

--- a/platform/photo-agent/tools/video_generator.py
+++ b/platform/photo-agent/tools/video_generator.py
@@ -28,6 +28,10 @@ class VideoConfig:
     seconds_per_photo: int = 4
     crossfade_duration: float = 0.5
     bitrate: str = "3M"
+    # Holds the final frame for this many extra seconds at the end of the video,
+    # so a viewer looping playback gets a moment to read it before it restarts.
+    # Set to 0 to disable.
+    freeze_duration: float = 1.5
 
     def __post_init__(self) -> None:
         if self.crossfade_duration < 0:
@@ -37,6 +41,8 @@ class VideoConfig:
                 f"crossfade_duration ({self.crossfade_duration}) must be less than "
                 f"seconds_per_photo ({self.seconds_per_photo}) — xfade offsets would be <= 0"
             )
+        if self.freeze_duration < 0:
+            raise ValueError(f"freeze_duration must be >= 0, got {self.freeze_duration}")
 
 
 class VideoGenerationError(Exception):
@@ -112,6 +118,21 @@ def _scale_crop_filter(i: int, config: VideoConfig, output_duration: float | Non
     )
 
 
+def _freeze_filter(config: VideoConfig, source_label: str) -> tuple[str, str]:
+    """Build a tpad filter segment that holds the last frame of source_label.
+
+    Args:
+        config: Video configuration (uses freeze_duration).
+        source_label: Bracketed input label, e.g. "[v0]" or "[xout]".
+
+    Returns (filter_segment, output_label) — output_label is always "[vout]".
+    """
+    return (
+        f"{source_label}tpad=stop_mode=clone:stop_duration={config.freeze_duration:g}[vout]",
+        "[vout]",
+    )
+
+
 def _output_flags(config: VideoConfig) -> list[str]:
     """Build the shared encoding output flags."""
     return [
@@ -126,11 +147,16 @@ def _output_flags(config: VideoConfig) -> list[str]:
 
 def _build_single_photo_cmd(photo: Path, config: VideoConfig, output_path: Path) -> list[str]:
     """FFmpeg command for N=1: read the still image once; zoompan expands it to full duration."""
+    filters = [_scale_crop_filter(0, config)]
+    map_label = "[v0]"
+    if config.freeze_duration > 0:
+        freeze_filter, map_label = _freeze_filter(config, "[v0]")
+        filters.append(freeze_filter)
     return [
         "ffmpeg",
         "-i", str(photo),
-        "-filter_complex", _scale_crop_filter(0, config),
-        "-map", "[v0]",
+        "-filter_complex", ";".join(filters),
+        "-map", map_label,
         *_output_flags(config),
         str(output_path),
     ]
@@ -166,9 +192,14 @@ def _build_multi_photo_cmd(photos: list[Path], config: VideoConfig, output_path:
             f"{left}{right}xfade=transition=fade:duration={xfade:g}:offset={offset:g}{out}"
         )
 
+    map_label = "[xout]"
+    if config.freeze_duration > 0:
+        freeze_filter, map_label = _freeze_filter(config, "[xout]")
+        filters.append(freeze_filter)
+
     cmd += [
         "-filter_complex", ";".join(filters),
-        "-map", "[xout]",
+        "-map", map_label,
         *_output_flags(config),
         str(output_path),
     ]


### PR DESCRIPTION
## Summary
- Adds `VideoConfig.freeze_duration` (default 1.5s) to `platform/photo-agent/tools/video_generator.py` — holds the last frame via an ffmpeg `tpad` filter so a looping viewer gets a moment to read the final frame before it restarts.
- Applies to both the N=1 zoompan path and the N≥2 xfade chain; `freeze_duration=0` disables it and preserves prior `-map` behavior exactly.
- `process_photos.py`'s `duration_sec` (used in the Telegram approval message and activity log) now accounts for the freeze.
- This is shared code, so it affects every video the pipeline produces — the e2e test video and real client videos posted to Facebook/Instagram alike.

## Test plan
- [x] `pytest tests/` in `platform/photo-agent` — 553 passing, 2 skipped (4 pre-existing failures in `test_process_photos_skill_timeout_fallback.py` are unrelated — confirmed identical on `main`, caused by a hardcoded `~/src/fieldkit` path in that test's environment)
- [x] New/updated unit tests cover the tpad filter injection, the `freeze_duration=0` disabled case, and validation of negative values
- [x] Existing real-ffmpeg duration/xfade-formula integration tests isolated with `freeze_duration=0` so they keep testing what they were built to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)